### PR TITLE
Architecture improvements follow-up

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
 	"require-dev": {
 		"fig-r/psr2r-sniffer": "@stable",
 		"phpunit/phpunit": "^10.5 || ^11.5 || ^12.1 || ^13.0",
-		"sebastian/diff": "@stable"
+		"sebastian/diff": "@stable",
+		"phpstan/phpstan": "^2.0"
 	},
 	"minimum-stability": "stable",
 	"prefer-stable": true,

--- a/src/Docs/DiffTrait.php
+++ b/src/Docs/DiffTrait.php
@@ -34,7 +34,7 @@ trait DiffTrait {
 	/**
 	 * @param string $content
 	 *
-	 * @return array<string>
+	 * @return list<string>
 	 */
 	protected function toSimpleArray(string $content): array {
 		return explode(PHP_EOL, $content);

--- a/src/MediaEmbed.php
+++ b/src/MediaEmbed.php
@@ -7,6 +7,7 @@ use MediaEmbed\Exception\InvalidUrlException;
 use MediaEmbed\Exception\ProviderNotFoundException;
 use MediaEmbed\Http\HttpClientInterface;
 use MediaEmbed\Http\StreamHttpClient;
+use MediaEmbed\Matcher\UrlMatcher;
 use MediaEmbed\Object\MediaObject;
 use MediaEmbed\Provider\PhpFileLoader;
 use MediaEmbed\Provider\ProviderConfig;
@@ -47,6 +48,11 @@ class MediaEmbed {
 	 * HTTP client for fetching remote content.
 	 */
 	protected HttpClientInterface $httpClient;
+
+	/**
+	 * URL matcher with domain-based caching.
+	 */
+	protected ?UrlMatcher $urlMatcher = null;
 
 	/**
 	 * Get the HTTP client.
@@ -201,27 +207,23 @@ class MediaEmbed {
 	 * @return \MediaEmbed\Object\MediaObject|null
 	 */
 	public function parseUrl(string $url, array $config = []): ?MediaObject {
-		foreach ($this->_hosts as $stub) {
-			$match = $this->_matchUrl($url, (array)$stub['url-match']);
-			if (!$match) {
-				continue;
-			}
-
-			$this->_match = $match;
-
-			if (!empty($stub['fetch-match'])) {
-				if (!$this->_parseLink($url, $stub['fetch-match'])) {
-					return null;
-				}
-			}
-
-			$stub['match'] = $this->_match;
-			$Object = $this->object($stub, $config + $this->config);
-
-			return $Object;
+		$result = $this->getUrlMatcher()->match($url);
+		if ($result === null) {
+			return null;
 		}
 
-		return null;
+		$stub = $result->providerStub;
+		$this->_match = $result->matches;
+
+		if (!empty($stub['fetch-match'])) {
+			if (!$this->_parseLink($url, $stub['fetch-match'])) {
+				return null;
+			}
+		}
+
+		$stub['match'] = $this->_match;
+
+		return $this->object($stub, $config + $this->config);
 	}
 
 	/**
@@ -234,31 +236,41 @@ class MediaEmbed {
      * @return \MediaEmbed\Object\MediaObject
 	 */
 	public function parseUrlOrFail(string $url, array $config = []): MediaObject {
-		foreach ($this->_hosts as $stub) {
-			$match = $this->_matchUrl($url, (array)$stub['url-match']);
-			if (!$match) {
-				continue;
-			}
-
-			$this->_match = $match;
-
-			if (!empty($stub['fetch-match'])) {
-				if (!$this->_parseLink($url, $stub['fetch-match'])) {
-					throw new FetchException($url, sprintf('Failed to fetch and match content from URL: %s', $url));
-				}
-			}
-
-			$stub['match'] = $this->_match;
-
-			$object = $this->object($stub, $config + $this->config);
-			if ($object === null) {
-				throw new InvalidUrlException($url);
-			}
-
-			return $object;
+		$result = $this->getUrlMatcher()->match($url);
+		if ($result === null) {
+			throw new InvalidUrlException($url);
 		}
 
-		throw new InvalidUrlException($url);
+		$stub = $result->providerStub;
+		$this->_match = $result->matches;
+
+		if (!empty($stub['fetch-match'])) {
+			if (!$this->_parseLink($url, $stub['fetch-match'])) {
+				throw new FetchException($url, sprintf('Failed to fetch and match content from URL: %s', $url));
+			}
+		}
+
+		$stub['match'] = $this->_match;
+
+		$object = $this->object($stub, $config + $this->config);
+		if ($object === null) {
+			throw new InvalidUrlException($url);
+		}
+
+		return $object;
+	}
+
+	/**
+	 * Get the URL matcher (lazy initialization).
+	 *
+	 * @return \MediaEmbed\Matcher\UrlMatcher
+	 */
+	public function getUrlMatcher(): UrlMatcher {
+		if ($this->urlMatcher === null) {
+			$this->urlMatcher = new UrlMatcher($this->_hosts);
+		}
+
+		return $this->urlMatcher;
 	}
 
 	/**
@@ -322,11 +334,15 @@ class MediaEmbed {
 			$this->_hosts[$slug] = $stub;
 		}
 
+		$this->urlMatcher = null; // Reset matcher when hosts change
+
 		return $this;
 	}
 
 	/**
 	 * Add a single provider dynamically.
+	 *
+	 * @deprecated Use addProviderConfig() with ProviderConfig DTO for type-safe provider configuration.
 	 *
 	 * @param array<string, mixed> $provider Provider configuration array.
 	 * @param bool $override Whether to override existing provider with same name.
@@ -348,6 +364,7 @@ class MediaEmbed {
 		}
 
 		$this->_hosts[$slug] = $provider;
+		$this->urlMatcher = null; // Reset matcher when providers change
 
 		return $this;
 	}
@@ -427,6 +444,8 @@ class MediaEmbed {
 	}
 
 	/**
+	 * @deprecated Use getProvider() which returns a ProviderConfig DTO.
+	 *
 	 * @param string $alias
 	 * @return array<string, mixed>|null Host info or null on failure
 	 */
@@ -444,9 +463,11 @@ class MediaEmbed {
 	/**
 	 * Get a provider by alias or throw exception if not found.
 	 *
-     * @param string $alias
-     * @throws \MediaEmbed\Exception\ProviderNotFoundException When provider is not found.
-     * @return array<string, mixed> Host info
+	 * @deprecated Use getProviderOrFail() which returns a ProviderConfig DTO.
+	 *
+	 * @param string $alias
+	 * @throws \MediaEmbed\Exception\ProviderNotFoundException When provider is not found.
+	 * @return array<string, mixed> Host info
 	 */
 	public function getHostOrFail(string $alias): array {
 		if (!$this->_hosts) {
@@ -507,6 +528,7 @@ class MediaEmbed {
 		}
 
 		$this->_hosts[$slug] = $array;
+		$this->urlMatcher = null; // Reset matcher when providers change
 
 		return $this;
 	}

--- a/src/Object/MediaObject.php
+++ b/src/Object/MediaObject.php
@@ -2,6 +2,8 @@
 
 namespace MediaEmbed\Object;
 
+use MediaEmbed\Template\TemplateResolver;
+
 /**
  * A generic object - for now.
  *
@@ -18,6 +20,11 @@ class MediaObject implements ObjectInterface {
 	 * @var array<string>
 	 */
 	protected array $_match;
+
+	/**
+	 * Template resolver for URL interpolation.
+	 */
+	protected TemplateResolver $templateResolver;
 
 	/**
 	 * @var array<string, mixed>
@@ -53,6 +60,7 @@ class MediaObject implements ObjectInterface {
 	 * @param array<string, mixed> $config
 	 */
 	public function __construct(array $stub, array $config) {
+		$this->templateResolver = new TemplateResolver();
 		$this->config = $config + $this->config;
 
 		$stubDefaults = [
@@ -91,11 +99,7 @@ class MediaObject implements ObjectInterface {
 		}
 
 		$flashvars = (string)$this->_objectParams['flashvars'];
-		if (strpos($flashvars, '$r2') !== false) {
-			$this->_objectParams['flashvars'] = str_replace('$r2', $this->_stub['id'], $flashvars);
-		} else {
-			$this->_objectParams['flashvars'] = str_replace('$2', $this->_stub['id'], $flashvars);
-		}
+		$this->_objectParams['flashvars'] = $this->templateResolver->resolveReverse($flashvars, $this->_stub['id']);
 	}
 
 	/**
@@ -113,14 +117,11 @@ class MediaObject implements ObjectInterface {
 			}
 			$this->_stub['id'] = $res[$count - 1];
 		}
-		$id = $this->_stub['id'];
 
-		for ($i = 1; $i <= $count; $i++) {
-			$id = str_ireplace('$' . $i, $res[$i - 1], $id);
-		}
+		$id = $this->templateResolver->resolve($this->_stub['id'], $res);
 
 		// If the ID is still a placeholder (no matches were provided), return empty string
-		if (preg_match('/^\$\d+$/', $id)) {
+		if ($this->templateResolver->hasUnresolvedPlaceholders($id)) {
 			return '';
 		}
 
@@ -142,19 +143,11 @@ class MediaObject implements ObjectInterface {
 	 * @return string
 	 */
 	public function name(): string {
-		$res = $this->_match;
-		$count = count($res);
-
 		if (empty($this->_stub['name'])) {
 			return '';
 		}
-		$name = $this->_stub['name'];
 
-		for ($i = 1; $i <= $count; $i++) {
-			$name = str_ireplace('$' . $i, $res[$i - 1], $name);
-		}
-
-		return $name;
+		return $this->templateResolver->resolve($this->_stub['name'], $this->_match);
 	}
 
 	/**
@@ -187,7 +180,7 @@ class MediaObject implements ObjectInterface {
 		}
 
 		$pieces = parse_url($url);
-		if (!$pieces) {
+		if (!$pieces || empty($pieces['host'])) {
 			return null;
 		}
 
@@ -375,12 +368,7 @@ class MediaObject implements ObjectInterface {
 	 * @return string The src attribute
 	 */
 	public function getEmbedSrc(): string {
-		$source = $this->_stub['iframe-player'];
-		$count = count($this->_match);
-
-		for ($i = 1; $i <= $count; $i++) {
-			$source = str_ireplace('$' . $i, $this->_match[$i - 1], $source);
-		}
+		$source = $this->templateResolver->resolve($this->_stub['iframe-player'], $this->_match);
 
 		//add custom params
 		if ($this->_iframeParams) {
@@ -406,15 +394,10 @@ class MediaObject implements ObjectInterface {
 		}
 
 		$stubSrc = $this->_stub[$type];
-		if (strpos($stubSrc, '$r2') !== false) {
-			$src = str_replace('$r2', $this->_stub['id'], $stubSrc);
-		} else {
-			$src = str_replace('$2', $this->_stub['id'], $stubSrc);
-		}
+		$src = $this->templateResolver->resolveReverse($stubSrc, $this->_stub['id']);
+
 		if (!empty($this->_stub['replace'])) {
-			foreach ((array)$this->_stub['replace'] as $placeholder => $replacement) {
-				$src = str_replace($placeholder, $replacement, $src);
-			}
+			$src = $this->templateResolver->resolveReplacements($src, (array)$this->_stub['replace']);
 		}
 
 		return $src;
@@ -431,14 +414,7 @@ class MediaObject implements ObjectInterface {
 			return null;
 		}
 
-		$stubImgSrc = $this->_stub['image-src'];
-		if (strpos($stubImgSrc, '$r2') !== false) {
-			$src = str_replace('$r2', $this->_stub['id'], $stubImgSrc);
-		} else {
-			$src = str_replace('$2', $this->_stub['id'], $stubImgSrc);
-		}
-
-		return $src;
+		return $this->templateResolver->resolveReverse($this->_stub['image-src'], $this->_stub['id']);
 	}
 
 	/**
@@ -450,14 +426,8 @@ class MediaObject implements ObjectInterface {
 		if (empty($this->_stub['image-src'])) {
 			return '';
 		}
-		$thumb = $this->_stub['image-src'];
 
-		$count = count($this->_match);
-		for ($i = 1; $i <= $count; $i++) {
-			$thumb = str_ireplace('$' . $i, $this->_match[$i - 1], $thumb);
-		}
-
-		return $thumb;
+		return $this->templateResolver->resolve($this->_stub['image-src'], $this->_match);
 	}
 
 	/**
@@ -498,12 +468,7 @@ class MediaObject implements ObjectInterface {
 	 * @return string
 	 */
 	protected function _buildIframe(): string {
-		$source = $this->_stub['iframe-player'];
-		$count = count($this->_match);
-
-		for ($i = 1; $i <= $count; $i++) {
-			$source = str_ireplace('$' . $i, $this->_match[$i - 1], $source);
-		}
+		$source = $this->templateResolver->resolve($this->_stub['iframe-player'], $this->_match);
 
 		//add custom params
 		if ($this->_iframeParams) {
@@ -536,14 +501,10 @@ class MediaObject implements ObjectInterface {
 	 * @return void
 	 */
 	protected function _setDefaultParams(array $stub): void {
-		$source = $stub['embed-src'];
-		$flashvars = (isset($stub['flashvars'])) ? $stub['flashvars'] : null;
-		$count = count($this->_match);
-
-		for ($i = 1; $i <= $count; $i++) {
-			$source = str_ireplace('$' . $i, $this->_match[$i - 1], $source);
-			$flashvars = str_ireplace('$' . $i, $this->_match[$i - 1], $flashvars ?? '');
-		}
+		$source = $this->templateResolver->resolve($stub['embed-src'], $this->_match);
+		$flashvars = isset($stub['flashvars'])
+			? $this->templateResolver->resolve($stub['flashvars'], $this->_match)
+			: null;
 
 		if ($source) {
 			$source = $this->_esc($source);


### PR DESCRIPTION
## Summary

Follow-up improvements to the architecture modernization (PR #81):

- **UrlMatcher integration**: parseUrl() now uses domain-based indexing for O(1) lookups instead of O(n) iteration
- **TemplateResolver integration**: MediaObject now uses TemplateResolver, replacing 6 duplicate for-loops with centralized template handling
- **Deprecation notices**: Added @deprecated docblock annotations to array-based methods (addProvider, getHost, getHostOrFail) pointing users to DTO-based alternatives
- **PHPStan 2.x upgrade**: Upgraded from 1.x to 2.x and fixed new type errors (list<string> annotation, nullable offset access)

All 119 tests pass.