### PR TITLE
Add BC-safe enhancements: ProviderCollection, cache, oEmbed

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -347,6 +347,145 @@ $loader = new ArrayLoader([
 $MediaEmbed->loadProvidersFromLoader($loader, reset: true);
 ```
 
+### Provider Collection
+
+Get all providers as a filterable collection:
+
+```php
+use MediaEmbed\Provider\ProviderCollection;
+
+$MediaEmbed = new MediaEmbed();
+
+// Get all providers
+$providers = $MediaEmbed->getProviders();
+echo count($providers); // e.g., 137
+
+// Filter to specific providers
+$subset = $MediaEmbed->getProviders(['youtube', 'vimeo', 'dailymotion']);
+
+// Filter by capabilities
+$withIframe = $providers->withIframeSupport();
+$withThumbnails = $providers->withThumbnailSupport();
+
+// Iterate over providers
+foreach ($providers as $slug => $config) {
+    echo $config->name . ' (' . $slug . ')' . PHP_EOL;
+}
+
+// Chain filters
+$filtered = $providers
+    ->withIframeSupport()
+    ->whitelist(['youtube', 'vimeo', 'twitch']);
+```
+
+### Caching
+
+For better performance on repeated requests, use the cache support:
+
+```php
+use MediaEmbed\Cache\ArrayCache;
+use MediaEmbed\Cache\CacheInterface;
+
+// Using the built-in ArrayCache (in-memory, single request)
+$cache = new ArrayCache();
+$MediaEmbed = new MediaEmbed();
+$matcher = $MediaEmbed->getUrlMatcher();
+$matcher->setCache($cache);
+
+// The domain index will be cached after first match
+$MediaEmbed->parseUrl('https://youtube.com/watch?v=abc');
+```
+
+For persistent caching, implement `CacheInterface` with your preferred cache backend (Redis, Memcached, filesystem, etc.):
+
+```php
+use MediaEmbed\Cache\CacheInterface;
+use Psr\SimpleCache\CacheInterface as Psr16Cache;
+
+class Psr16Adapter implements CacheInterface {
+    public function __construct(private Psr16Cache $cache) {}
+
+    public function get(string $key, mixed $default = null): mixed {
+        return $this->cache->get($key, $default);
+    }
+
+    public function set(string $key, mixed $value, ?int $ttl = null): bool {
+        return $this->cache->set($key, $value, $ttl);
+    }
+
+    public function delete(string $key): bool {
+        return $this->cache->delete($key);
+    }
+
+    public function has(string $key): bool {
+        return $this->cache->has($key);
+    }
+}
+
+// Use with any PSR-16 cache
+$cache = new Psr16Adapter($yourPsr16Cache);
+$MediaEmbed->getUrlMatcher()->setCache($cache, ttl: 3600);
+```
+
+### oEmbed Discovery
+
+For URLs not covered by built-in providers, use oEmbed auto-discovery:
+
+```php
+use MediaEmbed\OEmbed\OEmbedDiscovery;
+
+$discovery = new OEmbedDiscovery();
+
+// Auto-discover and fetch oEmbed data
+$response = $discovery->discover('https://example.com/video/123');
+
+if ($response !== null) {
+    echo $response->title;
+    echo $response->providerName;
+
+    if ($response->hasHtml()) {
+        echo $response->html; // Ready-to-use embed code
+    }
+
+    if ($response->hasThumbnail()) {
+        echo $response->thumbnailUrl;
+    }
+}
+
+// With size constraints
+$response = $discovery->discover($url, maxWidth: 640, maxHeight: 480);
+
+// Or fetch directly from a known endpoint
+$response = $discovery->fetch('https://example.com/oembed?url=...');
+```
+
+The `OEmbedResponse` provides typed access to all oEmbed fields:
+
+```php
+$response->type;           // 'video', 'photo', 'link', or 'rich'
+$response->version;        // oEmbed version (usually '1.0')
+$response->title;          // Content title
+$response->authorName;     // Author/creator name
+$response->authorUrl;      // Author URL
+$response->providerName;   // Provider name (e.g., 'YouTube')
+$response->providerUrl;    // Provider homepage
+$response->thumbnailUrl;   // Thumbnail image URL
+$response->thumbnailWidth; // Thumbnail width
+$response->thumbnailHeight;// Thumbnail height
+$response->html;           // Embed HTML (for video/rich types)
+$response->width;          // Embed width
+$response->height;         // Embed height
+$response->url;            // Source URL (for photo type)
+$response->cacheAge;       // Suggested cache duration in seconds
+
+// Type checks
+$response->isVideo();
+$response->isPhoto();
+$response->isRich();
+$response->hasHtml();
+$response->hasThumbnail();
+```
+
 ### Example with BBCode
 
 #### Parse video content upon save (db input)

--- a/src/Cache/ArrayCache.php
+++ b/src/Cache/ArrayCache.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MediaEmbed\Cache;
+
+/**
+ * Simple in-memory array cache.
+ *
+ * This cache stores values in memory for the duration of the request.
+ * Use this when you don't need persistent caching.
+ */
+final class ArrayCache implements CacheInterface {
+
+	/**
+	 * @var array<string, mixed>
+	 */
+	private array $cache = [];
+
+	/**
+	 * @inheritDoc
+	 */
+	public function get(string $key, mixed $default = null): mixed {
+		return $this->cache[$key] ?? $default;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function set(string $key, mixed $value, ?int $ttl = null): bool {
+		$this->cache[$key] = $value;
+
+		return true;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function delete(string $key): bool {
+		unset($this->cache[$key]);
+
+		return true;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function has(string $key): bool {
+		return isset($this->cache[$key]);
+	}
+
+	/**
+	 * Clear all cached values.
+	 *
+	 * @return bool
+	 */
+	public function clear(): bool {
+		$this->cache = [];
+
+		return true;
+	}
+
+}

--- a/src/Cache/CacheInterface.php
+++ b/src/Cache/CacheInterface.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MediaEmbed\Cache;
+
+/**
+ * Simple cache interface compatible with PSR-16 SimpleCache.
+ *
+ * Implementations of this interface can wrap any PSR-16 compatible cache
+ * or provide custom caching logic.
+ */
+interface CacheInterface {
+
+	/**
+	 * Fetches a value from the cache.
+	 *
+	 * @param string $key The unique key of this item in the cache.
+	 * @param mixed $default Default value to return if the key does not exist.
+	 * @return mixed The value of the item from the cache, or $default if not found.
+	 */
+	public function get(string $key, mixed $default = null): mixed;
+
+	/**
+	 * Persists data in the cache.
+	 *
+	 * @param string $key The key of the item to store.
+	 * @param mixed $value The value of the item to store.
+	 * @param int|null $ttl Optional TTL in seconds.
+	 * @return bool True on success, false on failure.
+	 */
+	public function set(string $key, mixed $value, ?int $ttl = null): bool;
+
+	/**
+	 * Delete an item from the cache by its unique key.
+	 *
+	 * @param string $key The unique cache key.
+	 * @return bool True if the item was successfully removed, false otherwise.
+	 */
+	public function delete(string $key): bool;
+
+	/**
+	 * Determines whether an item is present in the cache.
+	 *
+	 * @param string $key The cache item key.
+	 * @return bool
+	 */
+	public function has(string $key): bool;
+
+}

--- a/src/Matcher/UrlMatcher.php
+++ b/src/Matcher/UrlMatcher.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace MediaEmbed\Matcher;
 
+use MediaEmbed\Cache\CacheInterface;
+
 /**
  * URL matcher with optional domain-based caching for faster lookups.
  *
@@ -11,6 +13,12 @@ namespace MediaEmbed\Matcher;
  * to reduce the number of regex patterns that need to be tested.
  */
 final class UrlMatcher {
+
+	/**
+	 * Cache key for the domain index.
+     * @var string
+	 */
+	private const CACHE_KEY = 'media_embed_domain_index';
 
 	/**
 	 * Domain-to-providers index for fast path matching.
@@ -32,10 +40,24 @@ final class UrlMatcher {
 	private bool $indexBuilt = false;
 
 	/**
-	 * @param array<string, array<string, mixed>> $providers Providers keyed by slug.
+	 * Optional cache for persisting the domain index.
 	 */
-	public function __construct(array $providers = []) {
+	private ?CacheInterface $cache = null;
+
+	/**
+	 * Cache TTL in seconds (default: 1 hour).
+	 */
+	private int $cacheTtl = 3600;
+
+	/**
+	 * @param array<string, array<string, mixed>> $providers Providers keyed by slug.
+	 * @param \MediaEmbed\Cache\CacheInterface|null $cache Optional cache for persisting domain index.
+	 * @param int $cacheTtl Cache TTL in seconds.
+	 */
+	public function __construct(array $providers = [], ?CacheInterface $cache = null, int $cacheTtl = 3600) {
 		$this->providers = $providers;
+		$this->cache = $cache;
+		$this->cacheTtl = $cacheTtl;
 	}
 
 	/**
@@ -48,6 +70,25 @@ final class UrlMatcher {
 		$this->providers = $providers;
 		$this->indexBuilt = false;
 		$this->domainIndex = [];
+
+		// Clear cached index when providers change
+		if ($this->cache !== null) {
+			$this->cache->delete(static::CACHE_KEY);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Set the cache implementation.
+	 *
+	 * @param \MediaEmbed\Cache\CacheInterface|null $cache Cache implementation.
+	 * @param int $ttl Cache TTL in seconds.
+	 * @return $this
+	 */
+	public function setCache(?CacheInterface $cache, int $ttl = 3600) {
+		$this->cache = $cache;
+		$this->cacheTtl = $ttl;
 
 		return $this;
 	}
@@ -118,6 +159,17 @@ final class UrlMatcher {
 			return;
 		}
 
+		// Try to load from cache first
+		if ($this->cache !== null) {
+			$cached = $this->cache->get(static::CACHE_KEY);
+			if (is_array($cached)) {
+				$this->domainIndex = $cached;
+				$this->indexBuilt = true;
+
+				return;
+			}
+		}
+
 		$this->domainIndex = [];
 
 		foreach ($this->providers as $slug => $provider) {
@@ -134,6 +186,11 @@ final class UrlMatcher {
 					}
 				}
 			}
+		}
+
+		// Store in cache
+		if ($this->cache !== null) {
+			$this->cache->set(static::CACHE_KEY, $this->domainIndex, $this->cacheTtl);
 		}
 
 		$this->indexBuilt = true;

--- a/src/MediaEmbed.php
+++ b/src/MediaEmbed.php
@@ -10,6 +10,7 @@ use MediaEmbed\Http\StreamHttpClient;
 use MediaEmbed\Matcher\UrlMatcher;
 use MediaEmbed\Object\MediaObject;
 use MediaEmbed\Provider\PhpFileLoader;
+use MediaEmbed\Provider\ProviderCollection;
 use MediaEmbed\Provider\ProviderConfig;
 use MediaEmbed\Provider\ProviderLoaderInterface;
 use URLify;
@@ -506,6 +507,18 @@ class MediaEmbed {
 		$host = $this->getHostOrFail($alias);
 
 		return ProviderConfig::fromArray($host);
+	}
+
+	/**
+	 * Get all providers as a collection.
+	 *
+	 * @param array<string> $whitelist Optional list of slugs to include.
+	 * @return \MediaEmbed\Provider\ProviderCollection
+	 */
+	public function getProviders(array $whitelist = []): ProviderCollection {
+		$hosts = $this->getHosts($whitelist);
+
+		return ProviderCollection::fromArray(array_values($hosts));
 	}
 
 	/**

--- a/src/OEmbed/OEmbedDiscovery.php
+++ b/src/OEmbed/OEmbedDiscovery.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MediaEmbed\OEmbed;
+
+use MediaEmbed\Http\HttpClientInterface;
+use MediaEmbed\Http\StreamHttpClient;
+
+/**
+ * Discovers and fetches oEmbed data from URLs.
+ *
+ * This class can:
+ * 1. Auto-discover oEmbed endpoints from HTML link tags
+ * 2. Fetch and parse oEmbed JSON responses
+ *
+ * @see https://oembed.com/
+ */
+final class OEmbedDiscovery {
+
+	/**
+	 * HTTP client for fetching URLs.
+	 */
+	private HttpClientInterface $httpClient;
+
+	/**
+	 * @param \MediaEmbed\Http\HttpClientInterface|null $httpClient HTTP client to use.
+	 */
+	public function __construct(?HttpClientInterface $httpClient = null) {
+		$this->httpClient = $httpClient ?? new StreamHttpClient();
+	}
+
+	/**
+	 * Discover and fetch oEmbed data for a URL.
+	 *
+	 * This will:
+	 * 1. Fetch the URL's HTML
+	 * 2. Look for oEmbed link tags
+	 * 3. Fetch the oEmbed endpoint
+	 * 4. Parse and return the response
+	 *
+	 * @param string $url The URL to discover oEmbed for.
+	 * @param int|null $maxWidth Maximum width for the embed.
+	 * @param int|null $maxHeight Maximum height for the embed.
+	 * @return \MediaEmbed\OEmbed\OEmbedResponse|null Response or null if not found.
+	 */
+	public function discover(string $url, ?int $maxWidth = null, ?int $maxHeight = null): ?OEmbedResponse {
+		$endpointUrl = $this->discoverEndpoint($url);
+		if ($endpointUrl === null) {
+			return null;
+		}
+
+		return $this->fetch($endpointUrl, $maxWidth, $maxHeight);
+	}
+
+	/**
+	 * Discover the oEmbed endpoint URL from HTML.
+	 *
+	 * @param string $url The page URL to check.
+	 * @return string|null The oEmbed endpoint URL or null if not found.
+	 */
+	public function discoverEndpoint(string $url): ?string {
+		$html = $this->httpClient->get($url);
+		if ($html === null) {
+			return null;
+		}
+
+		return $this->parseOEmbedLink($html);
+	}
+
+	/**
+	 * Fetch oEmbed data directly from an endpoint URL.
+	 *
+	 * @param string $endpointUrl The oEmbed endpoint URL.
+	 * @param int|null $maxWidth Maximum width for the embed.
+	 * @param int|null $maxHeight Maximum height for the embed.
+	 * @return \MediaEmbed\OEmbed\OEmbedResponse|null Response or null on failure.
+	 */
+	public function fetch(string $endpointUrl, ?int $maxWidth = null, ?int $maxHeight = null): ?OEmbedResponse {
+		$params = [];
+		if ($maxWidth !== null) {
+			$params['maxwidth'] = $maxWidth;
+		}
+		if ($maxHeight !== null) {
+			$params['maxheight'] = $maxHeight;
+		}
+
+		if ($params) {
+			$separator = strpos($endpointUrl, '?') !== false ? '&' : '?';
+			$endpointUrl .= $separator . http_build_query($params);
+		}
+
+		$json = $this->httpClient->get($endpointUrl);
+		if ($json === null) {
+			return null;
+		}
+
+		$data = json_decode($json, true);
+		if (!is_array($data)) {
+			return null;
+		}
+
+		return OEmbedResponse::fromArray($data);
+	}
+
+	/**
+	 * Parse oEmbed link from HTML.
+	 *
+	 * Looks for: <link rel="alternate" type="application/json+oembed" href="..." />
+	 *
+	 * @param string $html The HTML to parse.
+	 * @return string|null The oEmbed URL or null if not found.
+	 */
+	private function parseOEmbedLink(string $html): ?string {
+		// Match link tags with oembed type
+		$pattern = '/<link[^>]+type=["\']application\/json\+oembed["\'][^>]*>/i';
+		if (!preg_match($pattern, $html, $match)) {
+			// Try alternate pattern with type before rel
+			$pattern = '/<link[^>]+rel=["\']alternate["\'][^>]+type=["\']application\/json\+oembed["\'][^>]*>/i';
+			if (!preg_match($pattern, $html, $match)) {
+				return null;
+			}
+		}
+
+		$linkTag = $match[0];
+
+		// Extract href attribute
+		if (!preg_match('/href=["\']([^"\']+)["\']/i', $linkTag, $hrefMatch)) {
+			return null;
+		}
+
+		$href = $hrefMatch[1];
+
+		// Decode HTML entities
+		return html_entity_decode($href, ENT_QUOTES | ENT_HTML5);
+	}
+
+}

--- a/src/OEmbed/OEmbedResponse.php
+++ b/src/OEmbed/OEmbedResponse.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MediaEmbed\OEmbed;
+
+/**
+ * Represents an oEmbed response.
+ *
+ * @see https://oembed.com/
+ */
+final class OEmbedResponse {
+
+	/**
+	 * @param string $type The resource type (video, photo, link, rich).
+	 * @param string $version The oEmbed version number.
+	 * @param string|null $title A text title.
+	 * @param string|null $authorName The name of the author/owner.
+	 * @param string|null $authorUrl A URL for the author/owner.
+	 * @param string|null $providerName The name of the resource provider.
+	 * @param string|null $providerUrl The URL of the resource provider.
+	 * @param int|null $cacheAge The suggested cache lifetime in seconds.
+	 * @param string|null $thumbnailUrl A URL to a thumbnail image.
+	 * @param int|null $thumbnailWidth Width of the thumbnail.
+	 * @param int|null $thumbnailHeight Height of the thumbnail.
+	 * @param string|null $html The HTML required to embed (for video/rich).
+	 * @param int|null $width Width of the HTML element.
+	 * @param int|null $height Height of the HTML element.
+	 * @param string|null $url Source URL of the image (for photo type).
+	 */
+	public function __construct(
+		public readonly string $type,
+		public readonly string $version,
+		public readonly ?string $title = null,
+		public readonly ?string $authorName = null,
+		public readonly ?string $authorUrl = null,
+		public readonly ?string $providerName = null,
+		public readonly ?string $providerUrl = null,
+		public readonly ?int $cacheAge = null,
+		public readonly ?string $thumbnailUrl = null,
+		public readonly ?int $thumbnailWidth = null,
+		public readonly ?int $thumbnailHeight = null,
+		public readonly ?string $html = null,
+		public readonly ?int $width = null,
+		public readonly ?int $height = null,
+		public readonly ?string $url = null,
+	) {
+	}
+
+	/**
+	 * Create from JSON response data.
+	 *
+	 * @param array<string, mixed> $data
+	 * @return self
+	 */
+	public static function fromArray(array $data): self {
+		return new self(
+			type: (string)($data['type'] ?? 'link'),
+			version: (string)($data['version'] ?? '1.0'),
+			title: isset($data['title']) ? (string)$data['title'] : null,
+			authorName: isset($data['author_name']) ? (string)$data['author_name'] : null,
+			authorUrl: isset($data['author_url']) ? (string)$data['author_url'] : null,
+			providerName: isset($data['provider_name']) ? (string)$data['provider_name'] : null,
+			providerUrl: isset($data['provider_url']) ? (string)$data['provider_url'] : null,
+			cacheAge: isset($data['cache_age']) ? (int)$data['cache_age'] : null,
+			thumbnailUrl: isset($data['thumbnail_url']) ? (string)$data['thumbnail_url'] : null,
+			thumbnailWidth: isset($data['thumbnail_width']) ? (int)$data['thumbnail_width'] : null,
+			thumbnailHeight: isset($data['thumbnail_height']) ? (int)$data['thumbnail_height'] : null,
+			html: isset($data['html']) ? (string)$data['html'] : null,
+			width: isset($data['width']) ? (int)$data['width'] : null,
+			height: isset($data['height']) ? (int)$data['height'] : null,
+			url: isset($data['url']) ? (string)$data['url'] : null,
+		);
+	}
+
+	/**
+	 * Check if this is a video type.
+	 *
+	 * @return bool
+	 */
+	public function isVideo(): bool {
+		return $this->type === 'video';
+	}
+
+	/**
+	 * Check if this is a photo type.
+	 *
+	 * @return bool
+	 */
+	public function isPhoto(): bool {
+		return $this->type === 'photo';
+	}
+
+	/**
+	 * Check if this is a rich type.
+	 *
+	 * @return bool
+	 */
+	public function isRich(): bool {
+		return $this->type === 'rich';
+	}
+
+	/**
+	 * Check if this response has embeddable HTML.
+	 *
+	 * @return bool
+	 */
+	public function hasHtml(): bool {
+		return $this->html !== null && $this->html !== '';
+	}
+
+	/**
+	 * Check if this response has a thumbnail.
+	 *
+	 * @return bool
+	 */
+	public function hasThumbnail(): bool {
+		return $this->thumbnailUrl !== null && $this->thumbnailUrl !== '';
+	}
+
+}

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace MediaEmbed\Test\Cache;
+
+use MediaEmbed\Cache\ArrayCache;
+use MediaEmbed\Cache\CacheInterface;
+use MediaEmbed\Matcher\UrlMatcher;
+use PHPUnit\Framework\TestCase;
+
+class CacheTest extends TestCase {
+
+	public function testArrayCacheImplementsInterface(): void {
+		$cache = new ArrayCache();
+
+		$this->assertInstanceOf(CacheInterface::class, $cache);
+	}
+
+	public function testArrayCacheSetAndGet(): void {
+		$cache = new ArrayCache();
+
+		$this->assertFalse($cache->has('test_key'));
+		$this->assertNull($cache->get('test_key'));
+		$this->assertSame('default', $cache->get('test_key', 'default'));
+
+		$cache->set('test_key', ['foo' => 'bar']);
+
+		$this->assertTrue($cache->has('test_key'));
+		$this->assertSame(['foo' => 'bar'], $cache->get('test_key'));
+	}
+
+	public function testArrayCacheDelete(): void {
+		$cache = new ArrayCache();
+
+		$cache->set('key1', 'value1');
+		$cache->set('key2', 'value2');
+
+		$this->assertTrue($cache->has('key1'));
+		$this->assertTrue($cache->has('key2'));
+
+		$cache->delete('key1');
+
+		$this->assertFalse($cache->has('key1'));
+		$this->assertTrue($cache->has('key2'));
+	}
+
+	public function testArrayCacheClear(): void {
+		$cache = new ArrayCache();
+
+		$cache->set('key1', 'value1');
+		$cache->set('key2', 'value2');
+
+		$cache->clear();
+
+		$this->assertFalse($cache->has('key1'));
+		$this->assertFalse($cache->has('key2'));
+	}
+
+	public function testUrlMatcherWithCache(): void {
+		$cache = new ArrayCache();
+
+		$providers = [
+			'test' => [
+				'name' => 'Test Provider',
+				'url-match' => ['test\\.example\\.com/video/([0-9]+)'],
+			],
+		];
+
+		$matcher = new UrlMatcher($providers, $cache);
+
+		// First match - should build and cache the index
+		$result = $matcher->match('https://test.example.com/video/123');
+		$this->assertNotNull($result);
+		$this->assertSame('test', $result->providerSlug);
+
+		// Verify cache has the index
+		$this->assertTrue($cache->has('media_embed_domain_index'));
+
+		// Create new matcher with same cache - should use cached index
+		$matcher2 = new UrlMatcher($providers, $cache);
+		$result2 = $matcher2->match('https://test.example.com/video/456');
+		$this->assertNotNull($result2);
+		$this->assertSame('test', $result2->providerSlug);
+	}
+
+	public function testUrlMatcherCacheInvalidation(): void {
+		$cache = new ArrayCache();
+
+		$providers = [
+			'test' => [
+				'name' => 'Test Provider',
+				'url-match' => ['test\\.example\\.com/video/([0-9]+)'],
+			],
+		];
+
+		$matcher = new UrlMatcher($providers, $cache);
+		$matcher->match('https://test.example.com/video/123');
+
+		$this->assertTrue($cache->has('media_embed_domain_index'));
+
+		// Setting new providers should invalidate cache
+		$matcher->setProviders([
+			'other' => [
+				'name' => 'Other Provider',
+				'url-match' => ['other\\.example\\.com/v/([a-z]+)'],
+			],
+		]);
+
+		$this->assertFalse($cache->has('media_embed_domain_index'));
+	}
+
+}

--- a/tests/MediaEmbedTest.php
+++ b/tests/MediaEmbedTest.php
@@ -535,4 +535,32 @@ class MediaEmbedTest extends TestCase {
 		unlink($tempFile);
 	}
 
+	/**
+	 * Test getProviders() returning ProviderCollection
+	 *
+	 * @return void
+	 */
+	public function testGetProviders(): void {
+		$MediaEmbed = new MediaEmbed();
+
+		$providers = $MediaEmbed->getProviders();
+		$this->assertGreaterThan(30, count($providers));
+		$this->assertTrue($providers->has('youtube'));
+		$this->assertTrue($providers->has('vimeo'));
+
+		// Test whitelist
+		$filtered = $MediaEmbed->getProviders(['youtube', 'vimeo']);
+		$this->assertCount(2, $filtered);
+		$this->assertTrue($filtered->has('youtube'));
+		$this->assertTrue($filtered->has('vimeo'));
+		$this->assertFalse($filtered->has('dailymotion'));
+
+		// Test collection methods
+		$withIframe = $providers->withIframeSupport();
+		$this->assertGreaterThan(0, count($withIframe));
+
+		$withThumbnail = $providers->withThumbnailSupport();
+		$this->assertGreaterThan(0, count($withThumbnail));
+	}
+
 }

--- a/tests/OEmbed/OEmbedTest.php
+++ b/tests/OEmbed/OEmbedTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace MediaEmbed\Test\OEmbed;
+
+use MediaEmbed\Http\HttpClientInterface;
+use MediaEmbed\OEmbed\OEmbedDiscovery;
+use MediaEmbed\OEmbed\OEmbedResponse;
+use PHPUnit\Framework\TestCase;
+
+class OEmbedTest extends TestCase {
+
+	public function testOEmbedResponseFromArray(): void {
+		$data = [
+			'type' => 'video',
+			'version' => '1.0',
+			'title' => 'Test Video',
+			'author_name' => 'Test Author',
+			'provider_name' => 'TestTube',
+			'provider_url' => 'https://testtube.example.com',
+			'thumbnail_url' => 'https://testtube.example.com/thumb.jpg',
+			'thumbnail_width' => 480,
+			'thumbnail_height' => 360,
+			'html' => '<iframe src="..."></iframe>',
+			'width' => 640,
+			'height' => 480,
+		];
+
+		$response = OEmbedResponse::fromArray($data);
+
+		$this->assertSame('video', $response->type);
+		$this->assertSame('1.0', $response->version);
+		$this->assertSame('Test Video', $response->title);
+		$this->assertSame('Test Author', $response->authorName);
+		$this->assertSame('TestTube', $response->providerName);
+		$this->assertSame('https://testtube.example.com', $response->providerUrl);
+		$this->assertSame(640, $response->width);
+		$this->assertSame(480, $response->height);
+		$this->assertTrue($response->isVideo());
+		$this->assertFalse($response->isPhoto());
+		$this->assertTrue($response->hasHtml());
+		$this->assertTrue($response->hasThumbnail());
+	}
+
+	public function testOEmbedResponsePhotoType(): void {
+		$data = [
+			'type' => 'photo',
+			'version' => '1.0',
+			'url' => 'https://example.com/image.jpg',
+			'width' => 800,
+			'height' => 600,
+		];
+
+		$response = OEmbedResponse::fromArray($data);
+
+		$this->assertTrue($response->isPhoto());
+		$this->assertFalse($response->isVideo());
+		$this->assertFalse($response->hasHtml());
+		$this->assertSame('https://example.com/image.jpg', $response->url);
+	}
+
+	public function testOEmbedResponseRichType(): void {
+		$data = [
+			'type' => 'rich',
+			'version' => '1.0',
+			'html' => '<div>Rich content</div>',
+		];
+
+		$response = OEmbedResponse::fromArray($data);
+
+		$this->assertTrue($response->isRich());
+		$this->assertTrue($response->hasHtml());
+	}
+
+	public function testOEmbedDiscoveryParseEndpoint(): void {
+		$mockClient = $this->createMock(HttpClientInterface::class);
+		$mockClient->method('get')
+			->willReturn('<html><head><link rel="alternate" type="application/json+oembed" href="https://example.com/oembed?url=test" /></head></html>');
+
+		$discovery = new OEmbedDiscovery($mockClient);
+		$endpoint = $discovery->discoverEndpoint('https://example.com/video/123');
+
+		$this->assertSame('https://example.com/oembed?url=test', $endpoint);
+	}
+
+	public function testOEmbedDiscoveryNoEndpoint(): void {
+		$mockClient = $this->createMock(HttpClientInterface::class);
+		$mockClient->method('get')
+			->willReturn('<html><head><title>No oEmbed</title></head></html>');
+
+		$discovery = new OEmbedDiscovery($mockClient);
+		$endpoint = $discovery->discoverEndpoint('https://example.com/page');
+
+		$this->assertNull($endpoint);
+	}
+
+	public function testOEmbedDiscoveryFetch(): void {
+		$mockClient = $this->createMock(HttpClientInterface::class);
+		$mockClient->method('get')
+			->willReturn(json_encode([
+				'type' => 'video',
+				'version' => '1.0',
+				'title' => 'Mock Video',
+				'html' => '<iframe></iframe>',
+			]));
+
+		$discovery = new OEmbedDiscovery($mockClient);
+		$response = $discovery->fetch('https://example.com/oembed?url=test');
+
+		$this->assertNotNull($response);
+		$this->assertSame('video', $response->type);
+		$this->assertSame('Mock Video', $response->title);
+	}
+
+	public function testOEmbedDiscoveryFetchWithDimensions(): void {
+		$mockClient = $this->createMock(HttpClientInterface::class);
+		$mockClient->expects($this->once())
+			->method('get')
+			->with($this->stringContains('maxwidth=640'))
+			->willReturn(json_encode([
+				'type' => 'video',
+				'version' => '1.0',
+			]));
+
+		$discovery = new OEmbedDiscovery($mockClient);
+		$discovery->fetch('https://example.com/oembed?url=test', 640, 480);
+	}
+
+}

--- a/tests/Provider/ProviderCollectionTest.php
+++ b/tests/Provider/ProviderCollectionTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace MediaEmbed\Test\Provider;
+
+use MediaEmbed\Provider\ProviderCollection;
+use MediaEmbed\Provider\ProviderConfig;
+use PHPUnit\Framework\TestCase;
+
+class ProviderCollectionTest extends TestCase {
+
+	public function testFromArray(): void {
+		$data = [
+			[
+				'name' => 'Provider1',
+				'website' => 'https://one.example.com',
+				'url-match' => 'one\\.example\\.com/([a-z]+)',
+				'embed-width' => '640',
+				'embed-height' => '360',
+				'iframe-player' => '//one.example.com/embed/$2',
+			],
+			[
+				'name' => 'Provider2',
+				'website' => 'https://two.example.com',
+				'url-match' => 'two\\.example\\.com/([a-z]+)',
+				'embed-width' => '800',
+				'embed-height' => '600',
+				'iframe-player' => '//two.example.com/embed/$2',
+			],
+		];
+
+		$collection = ProviderCollection::fromArray($data);
+
+		$this->assertCount(2, $collection);
+		$this->assertTrue($collection->has('provider1'));
+		$this->assertTrue($collection->has('provider2'));
+	}
+
+	public function testAddAndGet(): void {
+		$collection = new ProviderCollection();
+		$config = new ProviderConfig(
+			name: 'Test',
+			website: 'https://test.com',
+			urlMatch: 'pattern',
+			embedWidth: '640',
+			embedHeight: '360',
+			slug: 'test-provider',
+		);
+
+		$collection->add($config);
+
+		$this->assertTrue($collection->has('test-provider'));
+		$this->assertSame($config, $collection->get('test-provider'));
+	}
+
+	public function testFilter(): void {
+		$data = [
+			[
+				'name' => 'WithIframe',
+				'website' => 'https://iframe.example.com',
+				'url-match' => 'pattern1',
+				'embed-width' => '640',
+				'embed-height' => '360',
+				'iframe-player' => '//iframe.example.com/embed/$2',
+			],
+			[
+				'name' => 'WithoutIframe',
+				'website' => 'https://no-iframe.example.com',
+				'url-match' => 'pattern2',
+				'embed-width' => '640',
+				'embed-height' => '360',
+			],
+		];
+
+		$collection = ProviderCollection::fromArray($data);
+		$filtered = $collection->withIframeSupport();
+
+		$this->assertCount(1, $filtered);
+		$this->assertTrue($filtered->has('withiframe'));
+		$this->assertFalse($filtered->has('withoutiframe'));
+	}
+
+	public function testWhitelist(): void {
+		$data = [
+			[
+				'name' => 'Keep',
+				'website' => 'https://keep.example.com',
+				'url-match' => 'pattern1',
+				'embed-width' => '640',
+				'embed-height' => '360',
+			],
+			[
+				'name' => 'Remove',
+				'website' => 'https://remove.example.com',
+				'url-match' => 'pattern2',
+				'embed-width' => '640',
+				'embed-height' => '360',
+			],
+		];
+
+		$collection = ProviderCollection::fromArray($data);
+		$filtered = $collection->whitelist(['keep']);
+
+		$this->assertCount(1, $filtered);
+		$this->assertTrue($filtered->has('keep'));
+	}
+
+	public function testIterable(): void {
+		$data = [
+			[
+				'name' => 'One',
+				'website' => 'https://one.example.com',
+				'url-match' => 'pattern',
+				'embed-width' => '640',
+				'embed-height' => '360',
+			],
+		];
+
+		$collection = ProviderCollection::fromArray($data);
+		$count = 0;
+
+		foreach ($collection as $slug => $config) {
+			$this->assertSame('one', $slug);
+			$this->assertInstanceOf(ProviderConfig::class, $config);
+			$count++;
+		}
+
+		$this->assertSame(1, $count);
+	}
+
+	public function testSlugs(): void {
+		$data = [
+			[
+				'name' => 'Alpha',
+				'website' => 'https://alpha.example.com',
+				'url-match' => 'pattern',
+				'embed-width' => '640',
+				'embed-height' => '360',
+			],
+			[
+				'name' => 'Beta',
+				'website' => 'https://beta.example.com',
+				'url-match' => 'pattern',
+				'embed-width' => '640',
+				'embed-height' => '360',
+			],
+		];
+
+		$collection = ProviderCollection::fromArray($data);
+		$slugs = $collection->slugs();
+
+		$this->assertSame(['alpha', 'beta'], $slugs);
+	}
+
+}


### PR DESCRIPTION
## Summary

BC-safe enhancements to the architecture modernization:

### ProviderCollection Integration
- New `getProviders()` method returns a `ProviderCollection` for type-safe provider iteration
- Collection supports filtering (`withIframeSupport()`, `withThumbnailSupport()`, `whitelist()`)
- Implements `Countable` and `IteratorAggregate` for easy usage

### Cache Support
- New `CacheInterface` compatible with PSR-16 SimpleCache
- Built-in `ArrayCache` for in-memory caching
- `UrlMatcher` now accepts optional cache for persistent domain index
- Reduces startup time on subsequent requests when using persistent cache

### oEmbed Discovery
- New `OEmbedDiscovery` class for auto-discovering oEmbed endpoints from URLs
- `OEmbedResponse` DTO for parsed oEmbed data (includes title, author, thumbnails, etc.)
- Supports video, photo, rich, and link types
- Can be used alongside existing provider matching

### Documentation
- Added docs for ProviderCollection, caching, and oEmbed

Addresses #45 (oEmbed fallback / new major architecture)
Partially addresses #29 (metadata via oEmbed response)

All 139 tests pass.