### PR TITLE
Fix PHPCS final class static references

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,7 +5,9 @@
     <file>src/</file>
     <file>tests/</file>
 
-    <rule ref="PSR2R"/>
+    <rule ref="PSR2R">
+		<exclude name="PSR2R.PHP.PreferStaticOverSelf"/>
+	</rule>
 
 	<rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
 	<rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInClosureUse"/>

--- a/src/Matcher/UrlMatcher.php
+++ b/src/Matcher/UrlMatcher.php
@@ -73,7 +73,7 @@ final class UrlMatcher {
 
 		// Clear cached index when providers change
 		if ($this->cache !== null) {
-			$this->cache->delete(static::CACHE_KEY);
+			$this->cache->delete(self::CACHE_KEY);
 		}
 
 		return $this;
@@ -161,7 +161,7 @@ final class UrlMatcher {
 
 		// Try to load from cache first
 		if ($this->cache !== null) {
-			$cached = $this->cache->get(static::CACHE_KEY);
+			$cached = $this->cache->get(self::CACHE_KEY);
 			if (is_array($cached)) {
 				$this->domainIndex = $cached;
 				$this->indexBuilt = true;
@@ -190,7 +190,7 @@ final class UrlMatcher {
 
 		// Store in cache
 		if ($this->cache !== null) {
-			$this->cache->set(static::CACHE_KEY, $this->domainIndex, $this->cacheTtl);
+			$this->cache->set(self::CACHE_KEY, $this->domainIndex, $this->cacheTtl);
 		}
 
 		$this->indexBuilt = true;


### PR DESCRIPTION
Fixes the PHPCS failure from the updated sniff set by using self:: in the final UrlMatcher class and disabling the conflicting legacy PSR2R sniff.\n\nVerified locally:\n- composer cs-fix\n- composer cs-check\n- composer stan\n- composer test