### PR TITLE
Add HTML-safe embed src helper

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@ For stricter error handling, use the `*OrFail()` variants which throw exceptions
 ### Output
 You can then display the HTML code with `getEmbedCode()` or retrieve more information using the getters of `MediaObject`.
 
+`getEmbedSrc()` returns the embed source value without HTML attribute escaping. Use `getEmbedSrcForHtml()` when placing the source into your own iframe `src` attribute. `getEmbedCode()` already uses the HTML-safe value internally.
+
 
 ## Usage
 The simplest usage, when included via composer autoload, would be:

--- a/src/Object/MediaObject.php
+++ b/src/Object/MediaObject.php
@@ -327,14 +327,23 @@ class MediaObject implements ObjectInterface {
 	}
 
 	/**
-	 * Get the iframe src URL with parameters.
+	 * Get the raw iframe src URL with parameters.
 	 *
-	 * @return string The src attribute
+	 * @return string The unescaped src URL
 	 */
 	public function getEmbedSrc(): string {
 		$source = $this->templateResolver->resolve($this->stub['iframe-player'], $this->match);
 
 		return $this->appendQueryParams($source);
+	}
+
+	/**
+	 * Get the iframe src URL escaped for HTML attributes.
+	 *
+	 * @return string The escaped src attribute value
+	 */
+	public function getEmbedSrcForHtml(): string {
+		return $this->esc($this->getEmbedSrc());
 	}
 
 	/**
@@ -400,12 +409,9 @@ class MediaObject implements ObjectInterface {
 	 * @return string
 	 */
 	protected function buildIframe(): string {
-		$source = $this->templateResolver->resolve($this->stub['iframe-player'], $this->match);
-		$source = $this->appendQueryParams($source);
-
 		$attributes = $this->buildAttributeString();
 
-		return sprintf('<iframe src="%s"%s></iframe>', $this->esc($source), $attributes);
+		return sprintf('<iframe src="%s"%s></iframe>', $this->getEmbedSrcForHtml(), $attributes);
 	}
 
 	/**

--- a/src/Object/ObjectInterface.php
+++ b/src/Object/ObjectInterface.php
@@ -46,12 +46,21 @@ interface ObjectInterface {
 	public function getEmbedCode(): string;
 
 	/**
-	 * Returns the embed src. Useful for iframes where you only need the src attribute
+	 * Returns the raw embed src URL. Useful when the caller controls escaping.
 	 *
 	 * @api
 	 *
 	 * @return string
 	 */
 	public function getEmbedSrc(): string;
+
+	/**
+	 * Returns the HTML-escaped embed src URL for iframe src attributes.
+	 *
+	 * @api
+	 *
+	 * @return string
+	 */
+	public function getEmbedSrcForHtml(): string;
 
 }

--- a/tests/MediaEmbedTest.php
+++ b/tests/MediaEmbedTest.php
@@ -253,6 +253,8 @@ class MediaEmbedTest extends TestCase {
 
 		$this->assertStringContainsString('src="//unsafe.example.com/embed/12345?foo=1&amp;bar=&quot;quoted&quot;&amp;wmode=transparent"', $code);
 		$this->assertStringNotContainsString('bar="quoted"', $code);
+		$this->assertSame('//unsafe.example.com/embed/12345?foo=1&bar="quoted"&amp;wmode=transparent', $Object->getEmbedSrc());
+		$this->assertSame('//unsafe.example.com/embed/12345?foo=1&amp;bar=&quot;quoted&quot;&amp;wmode=transparent', $Object->getEmbedSrcForHtml());
 	}
 
 	/**


### PR DESCRIPTION
Adds an explicit `getEmbedSrcForHtml()` API for callers that build their own iframe attributes.

This keeps `getEmbedSrc()` behavior stable while documenting that generated embed HTML already uses the escaped value internally.

Local checks: `composer cs-fix && composer cs-check && composer stan && composer test`