### PR TITLE
Make timestamp query parameter provider-driven

### DIFF
--- a/data/stubs.php
+++ b/data/stubs.php
@@ -39,6 +39,7 @@ return [
 		'iframe-player' => '//www.youtube.com/embed/$2',
 		'id' => '$2',
 		'supports-timestamp' => true,
+		'timestamp-param' => 'start',
 	],
 	[
 		'name' => 'Facebook',

--- a/docs/README.md
+++ b/docs/README.md
@@ -234,6 +234,7 @@ $config = new ProviderConfig(
     slug: 'myprovider',           // Optional: Custom slug (auto-generated if omitted)
     imageSrc: '//.../$2.jpg',     // Optional: Thumbnail URL template
     supportsTimestamp: false,     // Optional: Timestamp support (like YouTube)
+    timestampParam: 'start',      // Optional: Embed query parameter for timestamps
 );
 ```
 
@@ -250,6 +251,7 @@ For array-based configs (legacy format):
 - **id**: Optional custom ID template
 - **fetch-match**: Optional regex for secondary HTTP lookup
 - **supports-timestamp**: Optional timestamp support flag
+- **timestamp-param**: Optional embed query parameter for timestamp values
 
 **Note:** In regex patterns and templates, `$1` is the full matched URL, `$2` is the first capture group, `$3` is the second, etc.
 

--- a/src/Object/MediaObject.php
+++ b/src/Object/MediaObject.php
@@ -85,7 +85,7 @@ class MediaObject implements ObjectInterface {
 			$src = $this->getObjectSrc('iframe-player');
 			$this->stub['iframe-player'] = $src;
 
-			// Handle timestamps for providers that support them (e.g., YouTube)
+			// Handle timestamps for providers that support them.
 			$this->handleTimestampSupport();
 		}
 	}
@@ -470,7 +470,7 @@ class MediaObject implements ObjectInterface {
 	}
 
 	/**
-	 * Handle timestamp support for providers that support it (e.g., YouTube)
+	 * Handle timestamp support for providers that support it.
 	 *
 	 * @return void
 	 */
@@ -485,16 +485,13 @@ class MediaObject implements ObjectInterface {
 			return;
 		}
 
-		$timestamp = $this->match[2];
-
-		// For YouTube, convert 't' parameter to 'start' parameter for embed URLs
-		if ($this->stub['slug'] === 'youtube') {
-			// Remove 's' suffix if present (e.g., "3724s" -> "3724")
-			$timestamp = rtrim($timestamp, 's');
-
-			// Add as iframe parameter
-			$this->iframeParams['start'] = $timestamp;
+		$timestampParam = $this->stub['timestamp-param'] ?? 'start';
+		if (!$timestampParam) {
+			return;
 		}
+
+		$timestamp = rtrim($this->match[2], 's');
+		$this->iframeParams[$timestampParam] = $timestamp;
 	}
 
 	/**

--- a/src/Provider/ProviderConfig.php
+++ b/src/Provider/ProviderConfig.php
@@ -26,6 +26,7 @@ final class ProviderConfig {
 	 * @param string|null $id Custom ID extraction pattern.
 	 * @param string|null $fetchMatch Secondary HTTP fetch regex.
 	 * @param bool $supportsTimestamp Whether provider supports timestamps.
+	 * @param string|null $timestampParam Embed query parameter for timestamp values.
 	 */
 	public function __construct(
 		public readonly string $name,
@@ -39,6 +40,7 @@ final class ProviderConfig {
 		public readonly ?string $id = null,
 		public readonly ?string $fetchMatch = null,
 		public readonly bool $supportsTimestamp = false,
+		public readonly ?string $timestampParam = null,
 	) {
 	}
 
@@ -79,6 +81,7 @@ final class ProviderConfig {
 			id: $data['id'] ?? null,
 			fetchMatch: $data['fetch-match'] ?? null,
 			supportsTimestamp: !empty($data['supports-timestamp']),
+			timestampParam: $data['timestamp-param'] ?? null,
 		);
 	}
 
@@ -113,6 +116,9 @@ final class ProviderConfig {
 		}
 		if ($this->supportsTimestamp) {
 			$array['supports-timestamp'] = true;
+		}
+		if ($this->timestampParam !== null) {
+			$array['timestamp-param'] = $this->timestampParam;
 		}
 
 		return $array;

--- a/tests/MediaEmbedTest.php
+++ b/tests/MediaEmbedTest.php
@@ -330,6 +330,25 @@ class MediaEmbedTest extends TestCase {
 		$this->assertStringContainsString('start=42', $code);
 	}
 
+	public function testCustomProviderTimestampParameter(): void {
+		$MediaEmbed = new MediaEmbed();
+		$MediaEmbed->addProviderConfig(new ProviderConfig(
+			name: 'TimedProvider',
+			website: 'https://timed.example.com',
+			urlMatch: 'https://timed\\.example\\.com/video/([0-9]+)\\?at=([0-9]+)',
+			embedWidth: 640,
+			embedHeight: 360,
+			iframePlayer: '//timed.example.com/embed/$2',
+			supportsTimestamp: true,
+			timestampParam: 'time',
+		));
+
+		$Object = $MediaEmbed->parseUrl('https://timed.example.com/video/12345?at=60');
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		$this->assertStringContainsString('time=60', $Object->getEmbedCode());
+	}
+
 	/**
 	 * @return void
 	 */

--- a/tests/Provider/ProviderConfigTest.php
+++ b/tests/Provider/ProviderConfigTest.php
@@ -40,6 +40,7 @@ class ProviderConfigTest extends TestCase {
 			'id' => '$2',
 			'fetch-match' => 'data-id="([a-z0-9]+)"',
 			'supports-timestamp' => true,
+			'timestamp-param' => 'start',
 		];
 
 		$config = ProviderConfig::fromArray($data);
@@ -50,6 +51,7 @@ class ProviderConfigTest extends TestCase {
 		$this->assertSame('$2', $config->id);
 		$this->assertSame('data-id="([a-z0-9]+)"', $config->fetchMatch);
 		$this->assertTrue($config->supportsTimestamp);
+		$this->assertSame('start', $config->timestampParam);
 	}
 
 	public function testFromArrayPreservesPercentageDimensions(): void {
@@ -121,6 +123,7 @@ class ProviderConfigTest extends TestCase {
 		$this->assertSame('//test.com/embed/$2', $array['iframe-player']);
 		$this->assertArrayNotHasKey('slug', $array);
 		$this->assertArrayNotHasKey('supports-timestamp', $array);
+		$this->assertArrayNotHasKey('timestamp-param', $array);
 	}
 
 	public function testGetUrlMatchPatterns(): void {


### PR DESCRIPTION
Adds `timestamp-param` provider config support and a `timestampParam` DTO property.

YouTube keeps its current `start` output via provider data, while custom providers can map timestamp captures to their own embed query parameter.

Local checks: `composer cs-fix && composer cs-check && composer stan && composer test`