### PR TITLE
Resolve relative oEmbed endpoints

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -475,6 +475,8 @@ $response = $discovery->discover($url, maxWidth: 640, maxHeight: 480);
 $response = $discovery->fetch('https://example.com/oembed?url=...');
 ```
 
+Discovered oEmbed endpoint URLs may be absolute, protocol-relative, root-relative, or path-relative. Relative endpoint URLs are resolved against the source page URL before they are fetched.
+
 The `OEmbedResponse` provides typed access to all oEmbed fields:
 
 ```php

--- a/src/OEmbed/OEmbedDiscovery.php
+++ b/src/OEmbed/OEmbedDiscovery.php
@@ -65,7 +65,7 @@ final class OEmbedDiscovery {
 			return null;
 		}
 
-		return $this->parseOEmbedLink($html);
+		return $this->parseOEmbedLink($html, $url);
 	}
 
 	/**
@@ -109,9 +109,10 @@ final class OEmbedDiscovery {
 	 * Looks for: <link rel="alternate" type="application/json+oembed" href="..." />
 	 *
 	 * @param string $html The HTML to parse.
+	 * @param string $baseUrl Source page URL.
 	 * @return string|null The oEmbed URL or null if not found.
 	 */
-	private function parseOEmbedLink(string $html): ?string {
+	private function parseOEmbedLink(string $html, string $baseUrl): ?string {
 		// Match link tags with oembed type
 		$pattern = '/<link[^>]+type=["\']application\/json\+oembed["\'][^>]*>/i';
 		if (!preg_match($pattern, $html, $match)) {
@@ -132,7 +133,45 @@ final class OEmbedDiscovery {
 		$href = $hrefMatch[1];
 
 		// Decode HTML entities
-		return html_entity_decode($href, ENT_QUOTES | ENT_HTML5);
+		$href = html_entity_decode($href, ENT_QUOTES | ENT_HTML5);
+
+		return $this->resolveEndpointUrl($href, $baseUrl);
+	}
+
+	/**
+	 * Resolve oEmbed href values against the source page URL.
+	 *
+	 * @param string $href Link href from the oEmbed tag.
+	 * @param string $baseUrl Source page URL.
+	 * @return string
+	 */
+	private function resolveEndpointUrl(string $href, string $baseUrl): string {
+		if (parse_url($href, PHP_URL_SCHEME) !== null) {
+			return $href;
+		}
+
+		$base = parse_url($baseUrl);
+		if (empty($base['scheme']) || empty($base['host'])) {
+			return $href;
+		}
+
+		$authority = $base['scheme'] . '://' . $base['host'];
+		if (!empty($base['port'])) {
+			$authority .= ':' . $base['port'];
+		}
+
+		if (str_starts_with($href, '//')) {
+			return $base['scheme'] . ':' . $href;
+		}
+
+		if (str_starts_with($href, '/')) {
+			return $authority . $href;
+		}
+
+		$path = $base['path'] ?? '/';
+		$directory = rtrim(substr($path, 0, (int)strrpos($path, '/') + 1), '/');
+
+		return $authority . $directory . '/' . $href;
 	}
 
 }

--- a/tests/OEmbed/OEmbedTest.php
+++ b/tests/OEmbed/OEmbedTest.php
@@ -82,6 +82,39 @@ class OEmbedTest extends TestCase {
 		$this->assertSame('https://example.com/oembed?url=test', $endpoint);
 	}
 
+	public function testOEmbedDiscoveryResolvesRootRelativeEndpoint(): void {
+		$mockClient = $this->createStub(HttpClientInterface::class);
+		$mockClient->method('get')
+			->willReturn('<html><head><link rel="alternate" type="application/json+oembed" href="/oembed?url=test" /></head></html>');
+
+		$discovery = new OEmbedDiscovery($mockClient);
+		$endpoint = $discovery->discoverEndpoint('https://example.com/video/123');
+
+		$this->assertSame('https://example.com/oembed?url=test', $endpoint);
+	}
+
+	public function testOEmbedDiscoveryResolvesPathRelativeEndpoint(): void {
+		$mockClient = $this->createStub(HttpClientInterface::class);
+		$mockClient->method('get')
+			->willReturn('<html><head><link rel="alternate" type="application/json+oembed" href="oembed?url=test" /></head></html>');
+
+		$discovery = new OEmbedDiscovery($mockClient);
+		$endpoint = $discovery->discoverEndpoint('https://example.com/videos/123');
+
+		$this->assertSame('https://example.com/videos/oembed?url=test', $endpoint);
+	}
+
+	public function testOEmbedDiscoveryResolvesProtocolRelativeEndpoint(): void {
+		$mockClient = $this->createStub(HttpClientInterface::class);
+		$mockClient->method('get')
+			->willReturn('<html><head><link rel="alternate" type="application/json+oembed" href="//cdn.example.com/oembed?url=test" /></head></html>');
+
+		$discovery = new OEmbedDiscovery($mockClient);
+		$endpoint = $discovery->discoverEndpoint('https://example.com/video/123');
+
+		$this->assertSame('https://cdn.example.com/oembed?url=test', $endpoint);
+	}
+
 	public function testOEmbedDiscoveryNoEndpoint(): void {
 		$mockClient = $this->createStub(HttpClientInterface::class);
 		$mockClient->method('get')


### PR DESCRIPTION
Resolves discovered oEmbed endpoint href values against the source page URL.

This covers absolute, protocol-relative, root-relative, and path-relative endpoint links before fetching the oEmbed response.

Local checks: `composer cs-fix && composer cs-check && composer stan && composer test`