### PR TITLE
Add provider configuration validation tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,9 @@ jobs:
       - name: Run phpcs
         run: composer cs-check
 
+      - name: Validate providers
+        run: composer validate-providers
+
       - name: Run link checker
         run: |
           sudo npm install -g markdown-link-check

--- a/bin/validate-providers.php
+++ b/bin/validate-providers.php
@@ -1,0 +1,38 @@
+#!/usr/bin/php -q
+<?php
+
+$options = [
+	__DIR__ . '/../vendor/autoload.php',
+	__DIR__ . '/vendor/autoload.php',
+];
+if (!empty($_SERVER['PWD'])) {
+	array_unshift($options, $_SERVER['PWD'] . '/vendor/autoload.php');
+}
+
+foreach ($options as $file) {
+	if (file_exists($file)) {
+		define('MEDIA_EMBED_COMPOSER_INSTALL', $file);
+		break;
+	}
+}
+require MEDIA_EMBED_COMPOSER_INSTALL;
+
+$path = $argv[1] ?? dirname(__DIR__) . '/data/stubs.php';
+$providers = include $path;
+if (!is_array($providers)) {
+	fwrite(STDERR, 'Provider file must return an array.' . PHP_EOL);
+	exit(1);
+}
+
+$validator = new \MediaEmbed\Provider\ProviderValidator();
+$errors = $validator->validate($providers);
+if (!$errors) {
+	echo 'Provider configuration is valid.' . PHP_EOL;
+	exit(0);
+}
+
+foreach ($errors as $error) {
+	fwrite(STDERR, $error . PHP_EOL);
+}
+
+exit(1);

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
 		}
 	},
 	"bin": [
-		"bin/generate-docs"
+		"bin/generate-docs",
+		"bin/validate-providers.php"
 	],
 	"config": {
 		"allow-plugins": {
@@ -56,6 +57,7 @@
 		"stan": "phpstan analyse",
 		"stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^1.0.0 && mv composer.backup composer.json",
 		"test": "phpunit",
-		"test-coverage": "phpunit --log-junit tmp/coverage/unitreport.xml --coverage-html tmp/coverage --coverage-clover tmp/coverage/coverage.xml"
+		"test-coverage": "phpunit --log-junit tmp/coverage/unitreport.xml --coverage-html tmp/coverage --coverage-clover tmp/coverage/coverage.xml",
+		"validate-providers": "php bin/validate-providers.php"
 	}
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -614,3 +614,8 @@ Update list of services in `docs/supported.md` with
 ```
 bin/generate-docs
 ```
+
+Validate provider configuration data with
+```
+composer validate-providers
+```

--- a/src/Provider/ProviderValidator.php
+++ b/src/Provider/ProviderValidator.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MediaEmbed\Provider;
+
+use URLify;
+
+/**
+ * Validates provider configuration arrays.
+ */
+final class ProviderValidator {
+
+	/**
+	 * @var array<string>
+	 */
+	private const REQUIRED_FIELDS = [
+		'name',
+		'website',
+		'url-match',
+		'embed-width',
+		'embed-height',
+		'iframe-player',
+	];
+
+	/**
+	 * Validate provider configuration arrays.
+	 *
+	 * @param array<array<string, mixed>> $providers
+	 * @return array<string> Validation errors.
+	 */
+	public function validate(array $providers): array {
+		$errors = [];
+		$slugs = [];
+
+		foreach ($providers as $index => $provider) {
+			$label = $this->label($provider, $index);
+			$this->validateRequiredFields($provider, $label, $errors);
+			$this->validateDimensions($provider, $label, $errors);
+			$this->validateUrlMatches($provider, $label, $errors);
+			$this->validateFetchMatch($provider, $label, $errors);
+			$this->validateSlug($provider, $label, $slugs, $errors);
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * @param array<string, mixed> $provider
+	 * @param string|int $index
+	 * @return string
+	 */
+	private function label(array $provider, string|int $index): string {
+		$name = $provider['name'] ?? null;
+		if (is_string($name) && $name !== '') {
+			return $name;
+		}
+
+		return 'provider #' . $index;
+	}
+
+	/**
+	 * @param array<string, mixed> $provider
+	 * @param string $label
+	 * @param array<string> $errors
+	 * @return void
+	 */
+	private function validateRequiredFields(array $provider, string $label, array &$errors): void {
+		foreach (self::REQUIRED_FIELDS as $field) {
+			if (!array_key_exists($field, $provider) || $provider[$field] === '' || $provider[$field] === []) {
+				$errors[] = $label . ': missing required field "' . $field . '"';
+			}
+		}
+	}
+
+	/**
+	 * @param array<string, mixed> $provider
+	 * @param string $label
+	 * @param array<string> $errors
+	 * @return void
+	 */
+	private function validateDimensions(array $provider, string $label, array &$errors): void {
+		foreach (['embed-width', 'embed-height'] as $field) {
+			if (!array_key_exists($field, $provider)) {
+				continue;
+			}
+			if (!is_int($provider[$field]) && !is_string($provider[$field])) {
+				$errors[] = $label . ': field "' . $field . '" must be an integer or string';
+			}
+		}
+	}
+
+	/**
+	 * @param array<string, mixed> $provider
+	 * @param string $label
+	 * @param array<string> $errors
+	 * @return void
+	 */
+	private function validateUrlMatches(array $provider, string $label, array &$errors): void {
+		if (!array_key_exists('url-match', $provider)) {
+			return;
+		}
+
+		$patterns = is_array($provider['url-match']) ? $provider['url-match'] : [$provider['url-match']];
+		foreach ($patterns as $pattern) {
+			if (!is_string($pattern) || $pattern === '') {
+				$errors[] = $label . ': url-match entries must be non-empty strings';
+
+				continue;
+			}
+			$this->validateRegex($pattern, $label, 'url-match', $errors);
+		}
+	}
+
+	/**
+	 * @param array<string, mixed> $provider
+	 * @param string $label
+	 * @param array<string> $errors
+	 * @return void
+	 */
+	private function validateFetchMatch(array $provider, string $label, array &$errors): void {
+		if (!array_key_exists('fetch-match', $provider)) {
+			return;
+		}
+
+		if (!is_string($provider['fetch-match']) || $provider['fetch-match'] === '') {
+			$errors[] = $label . ': fetch-match must be a non-empty string';
+
+			return;
+		}
+
+		$this->validateRegex($provider['fetch-match'], $label, 'fetch-match', $errors);
+	}
+
+	/**
+	 * @param string $pattern
+	 * @param string $label
+	 * @param string $field
+	 * @param array<string> $errors
+	 * @return void
+	 */
+	private function validateRegex(string $pattern, string $label, string $field, array &$errors): void {
+		set_error_handler(static function (): bool {
+			return true;
+		});
+		$result = preg_match('~' . $pattern . '~imu', '');
+		restore_error_handler();
+
+		if ($result === false) {
+			$errors[] = $label . ': invalid regex in "' . $field . '"';
+		}
+	}
+
+	/**
+	 * @param array<string, mixed> $provider
+	 * @param string $label
+	 * @param array<string, string> $slugs
+	 * @param array<string> $errors
+	 * @return void
+	 */
+	private function validateSlug(array $provider, string $label, array &$slugs, array &$errors): void {
+		$name = $provider['name'] ?? null;
+		$slug = $provider['slug'] ?? null;
+		if (!is_string($slug) || $slug === '') {
+			if (!is_string($name) || $name === '') {
+				return;
+			}
+			$slug = URLify::filter($name);
+		}
+
+		if (isset($slugs[$slug])) {
+			$errors[] = $label . ': duplicate slug "' . $slug . '" already used by ' . $slugs[$slug];
+
+			return;
+		}
+
+		$slugs[$slug] = $label;
+	}
+
+}

--- a/tests/Provider/ProviderValidatorTest.php
+++ b/tests/Provider/ProviderValidatorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace MediaEmbed\Test\Provider;
+
+use MediaEmbed\Provider\ProviderValidator;
+use PHPUnit\Framework\TestCase;
+
+class ProviderValidatorTest extends TestCase {
+
+	public function testValidateDefaultProviders(): void {
+		$providers = include dirname(__DIR__, 2) . '/data/stubs.php';
+
+		$validator = new ProviderValidator();
+
+		$this->assertSame([], $validator->validate($providers));
+	}
+
+	public function testValidateReportsInvalidProviderData(): void {
+		$providers = [
+			[
+				'name' => 'Broken',
+				'website' => 'https://broken.example.com',
+				'url-match' => ['broken\\.example\\.com/([0-9]+', ''],
+				'embed-width' => [],
+				'embed-height' => '360',
+				'iframe-player' => '',
+				'fetch-match' => '(',
+			],
+			[
+				'name' => 'Broken',
+				'website' => 'https://other.example.com',
+				'url-match' => 'other\\.example\\.com/([0-9]+)',
+				'embed-width' => 640,
+				'embed-height' => 360,
+				'iframe-player' => '//other.example.com/embed/$2',
+			],
+		];
+
+		$validator = new ProviderValidator();
+		$errors = $validator->validate($providers);
+
+		$this->assertContains('Broken: missing required field "iframe-player"', $errors);
+		$this->assertContains('Broken: field "embed-width" must be an integer or string', $errors);
+		$this->assertContains('Broken: invalid regex in "url-match"', $errors);
+		$this->assertContains('Broken: url-match entries must be non-empty strings', $errors);
+		$this->assertContains('Broken: invalid regex in "fetch-match"', $errors);
+		$this->assertContains('Broken: duplicate slug "broken" already used by Broken', $errors);
+	}
+
+}


### PR DESCRIPTION
Adds a reusable `ProviderValidator` and a `composer validate-providers` command for checking provider data.

The validator checks required fields, dimension types, regex compileability, fetch-match validity, and duplicate slugs.

Local checks: `composer validate-providers && composer cs-fix && composer cs-check && composer stan && composer test`