### PR TITLE
Align cache support with PSR-16

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -39,6 +39,8 @@ If you have custom providers using these keys, remove them.
 
 - `ProviderConfig::$embedWidth` - Now accepts `int|string` (was `string`)
 - `ProviderConfig::$embedHeight` - Now accepts `int|string` (was `string`)
+- `UrlMatcher` cache arguments now accept `Psr\SimpleCache\CacheInterface`
+- `MediaEmbed\Cache\CacheInterface` now extends PSR-16 and includes multi-key cache methods
 
 The `fromArray()` method preserves legacy array values as strings, including percentage dimensions such as `100%`.
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
 	],
 	"require": {
 		"php": ">=8.1",
-		"jbroadway/urlify": "^1.0.0"
+		"jbroadway/urlify": "^1.0.0",
+		"psr/simple-cache": "^3.0"
 	},
 	"require-dev": {
 		"fig-r/psr2r-sniffer": "@stable",

--- a/docs/README.md
+++ b/docs/README.md
@@ -412,39 +412,10 @@ $matcher->setCache($cache);
 $MediaEmbed->parseUrl('https://youtube.com/watch?v=abc');
 ```
 
-For persistent caching, implement `CacheInterface` with your preferred cache backend (Redis, Memcached, filesystem, etc.):
+For persistent caching, pass any PSR-16 cache implementation (Redis, Memcached, filesystem, etc.):
 
 ```php
-use MediaEmbed\Cache\CacheInterface;
-use Psr\SimpleCache\CacheInterface as Psr16Cache;
-
-class Psr16Adapter implements CacheInterface {
-    public function __construct(private Psr16Cache $cache) {}
-
-    public function get(string $key, mixed $default = null): mixed {
-        return $this->cache->get($key, $default);
-    }
-
-    public function set(string $key, mixed $value, ?int $ttl = null): bool {
-        return $this->cache->set($key, $value, $ttl);
-    }
-
-    public function delete(string $key): bool {
-        return $this->cache->delete($key);
-    }
-
-    public function has(string $key): bool {
-        return $this->cache->has($key);
-    }
-
-    public function clear(): bool {
-        return $this->cache->clear();
-    }
-}
-
-// Use with any PSR-16 cache
-$cache = new Psr16Adapter($yourPsr16Cache);
-$MediaEmbed->getUrlMatcher()->setCache($cache, ttl: 3600);
+$MediaEmbed->getUrlMatcher()->setCache($yourPsr16Cache, ttl: 3600);
 ```
 
 ### oEmbed Discovery

--- a/docs/README.md
+++ b/docs/README.md
@@ -400,9 +400,8 @@ For better performance on repeated requests, use the cache support:
 
 ```php
 use MediaEmbed\Cache\ArrayCache;
-use MediaEmbed\Cache\CacheInterface;
 
-// Using the built-in ArrayCache (in-memory, single request)
+// The built-in ArrayCache is in-memory and lasts for the current request only.
 $cache = new ArrayCache();
 $MediaEmbed = new MediaEmbed();
 $matcher = $MediaEmbed->getUrlMatcher();
@@ -415,8 +414,13 @@ $MediaEmbed->parseUrl('https://youtube.com/watch?v=abc');
 For persistent caching, pass any PSR-16 cache implementation (Redis, Memcached, filesystem, etc.):
 
 ```php
+use Psr\SimpleCache\CacheInterface;
+
+/** @var CacheInterface $yourPsr16Cache */
 $MediaEmbed->getUrlMatcher()->setCache($yourPsr16Cache, ttl: 3600);
 ```
+
+The cache stores the generated provider domain index under an internal key. It is invalidated automatically when `UrlMatcher::setProviders()` is called. The `ttl` argument controls how long persistent caches may retain the index.
 
 ### oEmbed Discovery
 

--- a/src/Cache/ArrayCache.php
+++ b/src/Cache/ArrayCache.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace MediaEmbed\Cache;
 
+use DateInterval;
+
 /**
  * Simple in-memory array cache.
  *
@@ -27,7 +29,7 @@ final class ArrayCache implements CacheInterface {
 	/**
 	 * @inheritDoc
 	 */
-	public function set(string $key, mixed $value, ?int $ttl = null): bool {
+	public function set(string $key, mixed $value, DateInterval|int|null $ttl = null): bool {
 		$this->cache[$key] = $value;
 
 		return true;
@@ -56,6 +58,46 @@ final class ArrayCache implements CacheInterface {
 	 */
 	public function clear(): bool {
 		$this->cache = [];
+
+		return true;
+	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @param iterable<string> $keys
+	 */
+	public function getMultiple(iterable $keys, mixed $default = null): iterable {
+		$values = [];
+		foreach ($keys as $key) {
+			$values[$key] = $this->get($key, $default);
+		}
+
+		return $values;
+	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @param iterable<string, mixed> $values
+	 */
+	public function setMultiple(iterable $values, DateInterval|int|null $ttl = null): bool {
+		foreach ($values as $key => $value) {
+			$this->set($key, $value, $ttl);
+		}
+
+		return true;
+	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @param iterable<string> $keys
+	 */
+	public function deleteMultiple(iterable $keys): bool {
+		foreach ($keys as $key) {
+			$this->delete($key);
+		}
 
 		return true;
 	}

--- a/src/Cache/CacheInterface.php
+++ b/src/Cache/CacheInterface.php
@@ -4,54 +4,10 @@ declare(strict_types=1);
 
 namespace MediaEmbed\Cache;
 
+use Psr\SimpleCache\CacheInterface as PsrCacheInterface;
+
 /**
- * Simple cache interface compatible with PSR-16 SimpleCache.
- *
- * Implementations of this interface can wrap any PSR-16 compatible cache
- * or provide custom caching logic.
+ * Cache interface for media-embed caches.
  */
-interface CacheInterface {
-
-	/**
-	 * Fetches a value from the cache.
-	 *
-	 * @param string $key The unique key of this item in the cache.
-	 * @param mixed $default Default value to return if the key does not exist.
-	 * @return mixed The value of the item from the cache, or $default if not found.
-	 */
-	public function get(string $key, mixed $default = null): mixed;
-
-	/**
-	 * Persists data in the cache.
-	 *
-	 * @param string $key The key of the item to store.
-	 * @param mixed $value The value of the item to store.
-	 * @param int|null $ttl Optional TTL in seconds.
-	 * @return bool True on success, false on failure.
-	 */
-	public function set(string $key, mixed $value, ?int $ttl = null): bool;
-
-	/**
-	 * Delete an item from the cache by its unique key.
-	 *
-	 * @param string $key The unique cache key.
-	 * @return bool True if the item was successfully removed, false otherwise.
-	 */
-	public function delete(string $key): bool;
-
-	/**
-	 * Determines whether an item is present in the cache.
-	 *
-	 * @param string $key The cache item key.
-	 * @return bool
-	 */
-	public function has(string $key): bool;
-
-	/**
-	 * Clear all cached values.
-	 *
-	 * @return bool True on success, false on failure.
-	 */
-	public function clear(): bool;
-
+interface CacheInterface extends PsrCacheInterface {
 }

--- a/src/Matcher/UrlMatcher.php
+++ b/src/Matcher/UrlMatcher.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MediaEmbed\Matcher;
 
-use MediaEmbed\Cache\CacheInterface;
+use Psr\SimpleCache\CacheInterface;
 
 /**
  * URL matcher with optional domain-based caching for faster lookups.
@@ -52,7 +52,7 @@ final class UrlMatcher {
 
 	/**
 	 * @param array<string, array<string, mixed>> $providers Providers keyed by slug.
-	 * @param \MediaEmbed\Cache\CacheInterface|null $cache Optional cache for persisting domain index.
+	 * @param \Psr\SimpleCache\CacheInterface|null $cache Optional cache for persisting domain index.
 	 * @param int $cacheTtl Cache TTL in seconds.
 	 */
 	public function __construct(array $providers = [], ?CacheInterface $cache = null, int $cacheTtl = 3600) {
@@ -83,7 +83,7 @@ final class UrlMatcher {
 	/**
 	 * Set the cache implementation.
 	 *
-	 * @param \MediaEmbed\Cache\CacheInterface|null $cache Cache implementation.
+	 * @param \Psr\SimpleCache\CacheInterface|null $cache Cache implementation.
 	 * @param int $ttl Cache TTL in seconds.
 	 * @return $this
 	 */

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -2,10 +2,12 @@
 
 namespace MediaEmbed\Test\Cache;
 
+use DateInterval;
 use MediaEmbed\Cache\ArrayCache;
 use MediaEmbed\Cache\CacheInterface;
 use MediaEmbed\Matcher\UrlMatcher;
 use PHPUnit\Framework\TestCase;
+use Psr\SimpleCache\CacheInterface as PsrCacheInterface;
 
 class CacheTest extends TestCase {
 
@@ -13,6 +15,7 @@ class CacheTest extends TestCase {
 		$cache = new ArrayCache();
 
 		$this->assertInstanceOf(CacheInterface::class, $cache);
+		$this->assertInstanceOf(PsrCacheInterface::class, $cache);
 	}
 
 	public function testArrayCacheSetAndGet(): void {
@@ -50,6 +53,26 @@ class CacheTest extends TestCase {
 		$cache->set('key2', 'value2');
 
 		$cache->clear();
+
+		$this->assertFalse($cache->has('key1'));
+		$this->assertFalse($cache->has('key2'));
+	}
+
+	public function testArrayCacheMultipleOperations(): void {
+		$cache = new ArrayCache();
+
+		$cache->setMultiple([
+			'key1' => 'value1',
+			'key2' => 'value2',
+		]);
+
+		$this->assertSame([
+			'key1' => 'value1',
+			'key2' => 'value2',
+			'key3' => 'default',
+		], $cache->getMultiple(['key1', 'key2', 'key3'], 'default'));
+
+		$cache->deleteMultiple(['key1', 'key2']);
 
 		$this->assertFalse($cache->has('key1'));
 		$this->assertFalse($cache->has('key2'));
@@ -106,6 +129,78 @@ class CacheTest extends TestCase {
 		]);
 
 		$this->assertFalse($cache->has('media_embed_domain_index'));
+	}
+
+	public function testUrlMatcherAcceptsPsrCache(): void {
+		$cache = new class () implements PsrCacheInterface {
+			/**
+			 * @var array<string, mixed>
+			 */
+			private array $cache = [];
+
+			public function get(string $key, mixed $default = null): mixed {
+				return $this->cache[$key] ?? $default;
+			}
+
+			public function set(string $key, mixed $value, DateInterval|int|null $ttl = null): bool {
+				$this->cache[$key] = $value;
+
+				return true;
+			}
+
+			public function delete(string $key): bool {
+				unset($this->cache[$key]);
+
+				return true;
+			}
+
+			public function clear(): bool {
+				$this->cache = [];
+
+				return true;
+			}
+
+			public function getMultiple(iterable $keys, mixed $default = null): iterable {
+				$values = [];
+				foreach ($keys as $key) {
+					$values[$key] = $this->get($key, $default);
+				}
+
+				return $values;
+			}
+
+			public function setMultiple(iterable $values, DateInterval|int|null $ttl = null): bool {
+				foreach ($values as $key => $value) {
+					$this->set($key, $value, $ttl);
+				}
+
+				return true;
+			}
+
+			public function deleteMultiple(iterable $keys): bool {
+				foreach ($keys as $key) {
+					$this->delete($key);
+				}
+
+				return true;
+			}
+
+			public function has(string $key): bool {
+				return isset($this->cache[$key]);
+			}
+		};
+
+		$matcher = new UrlMatcher([
+			'test' => [
+				'name' => 'Test Provider',
+				'url-match' => ['test\\.example\\.com/video/([0-9]+)'],
+			],
+		], $cache);
+
+		$result = $matcher->match('https://test.example.com/video/123');
+
+		$this->assertNotNull($result);
+		$this->assertTrue($cache->has('media_embed_domain_index'));
 	}
 
 }


### PR DESCRIPTION
Adds `psr/simple-cache` as an explicit dependency and aligns cache support with PSR-16.

`UrlMatcher` now accepts any PSR-16 cache implementation directly, while the built-in `ArrayCache` implements the full PSR-16 method set.

Local checks: `composer cs-fix && composer cs-check && composer stan && composer test`