### PR TITLE
Fix embed source template resolution

### DIFF
--- a/src/Object/MediaObject.php
+++ b/src/Object/MediaObject.php
@@ -81,10 +81,12 @@ class MediaObject implements ObjectInterface {
 
 		$this->setDefaultParams($stub);
 
-		if (isset($this->stub['iframe-player'])) {
+		if (!empty($this->stub['reverse']) && isset($this->stub['iframe-player'])) {
 			$src = $this->getObjectSrc('iframe-player');
 			$this->stub['iframe-player'] = $src;
+		}
 
+		if (isset($this->stub['iframe-player'])) {
 			// Handle timestamps for providers that support them.
 			$this->handleTimestampSupport();
 		}
@@ -425,9 +427,9 @@ class MediaObject implements ObjectInterface {
 			return $url;
 		}
 
-		$separator = str_contains($url, '?') ? '&amp;' : '?';
+		$separator = str_contains($url, '?') ? '&' : '?';
 
-		return $url . $separator . http_build_query($this->iframeParams, '', '&amp;');
+		return $url . $separator . http_build_query($this->iframeParams);
 	}
 
 	/**

--- a/tests/MediaEmbedTest.php
+++ b/tests/MediaEmbedTest.php
@@ -158,6 +158,37 @@ class MediaEmbedTest extends TestCase {
 	}
 
 	/**
+	 * @dataProvider getEmbedSrcUrls
+	 * @param string $url
+	 * @param string $expected
+	 * @return void
+	 */
+	#[DataProvider('getEmbedSrcUrls')]
+	public function testGetEmbedSrc(string $url, string $expected): void {
+		$MediaEmbed = new MediaEmbed();
+		$Object = $MediaEmbed->parseUrl($url);
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		$this->assertSame($expected, $Object->getEmbedSrc());
+	}
+
+	/**
+	 * Data provider for expected embed src URLs.
+	 *
+	 * @return array
+	 */
+	public static function getEmbedSrcUrls(): array {
+		return [
+			['https://www.mixcloud.com/spartacus/party-time/', '//www.mixcloud.com/widget/iframe/?feed=https%3A%2F%2Fwww.mixcloud.com%2Fspartacus%2Fparty-time%2F&wmode=transparent'],
+			['https://open.spotify.com/track/4iV5W9uYEdYUVa79Axb7Rh', 'https://open.spotify.com/embed/track/4iV5W9uYEdYUVa79Axb7Rh?wmode=transparent'],
+			['https://artist.bandcamp.com/track/song-title', 'https://bandcamp.com/EmbeddedPlayer/track=artist/size=large/bgcol=ffffff/linkcol=0687f5/tracklist=false/transparent=true/?wmode=transparent'],
+			['https://peertube.example.org/w/abc123XYZ', 'https://peertube.example.org/videos/embed/abc123XYZ?wmode=transparent'],
+			['https://www.metatube.com/en/videos/245145/J-Alvarez-Tu-Cuerpo-Pide-Fiesta/', 'https://www.metatube.com/en/videos/245145/J-Alvarez-Tu-Cuerpo-Pide-Fiesta/embed/?wmode=transparent'],
+			['https://lds.cdn.vooplayer.com/publish/MTEwNTMw', 'https://lds.cdn.vooplayer.com/publish/MTEwNTMw?fallback=true&wmode=transparent'],
+		];
+	}
+
+	/**
 	 * Test parseId()
 	 *
 	 * @return void
@@ -253,7 +284,7 @@ class MediaEmbedTest extends TestCase {
 
 		$this->assertStringContainsString('src="//unsafe.example.com/embed/12345?foo=1&amp;bar=&quot;quoted&quot;&amp;wmode=transparent"', $code);
 		$this->assertStringNotContainsString('bar="quoted"', $code);
-		$this->assertSame('//unsafe.example.com/embed/12345?foo=1&bar="quoted"&amp;wmode=transparent', $Object->getEmbedSrc());
+		$this->assertSame('//unsafe.example.com/embed/12345?foo=1&bar="quoted"&wmode=transparent', $Object->getEmbedSrc());
 		$this->assertSame('//unsafe.example.com/embed/12345?foo=1&amp;bar=&quot;quoted&quot;&amp;wmode=transparent', $Object->getEmbedSrcForHtml());
 	}
 


### PR DESCRIPTION
Fixes normal URL parsing so iframe-player templates resolve against regex matches instead of reverse-ID substitution.

This repairs malformed embed src output for multi-capture providers such as Mixcloud, Spotify, Bandcamp, PeerTube, Metatube, and Vooplayer. It also makes `getEmbedSrc()` return a raw URL while `getEmbedSrcForHtml()` remains the HTML-escaped variant used by generated iframe output.

Local checks: `composer cs-fix && composer cs-check && composer stan && composer test`