### PR TITLE
Validate iframe attribute names

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -107,6 +107,8 @@ This should return an embed code like:
 <iframe src="//www.youtube.com/embed/111111?wmode=transparent&amp;autoplay=1&amp;loop=1" width="480" height="295" frameborder="0" allowfullscreen class="iframe-class" data-html5-parameter></iframe>
 ```
 
+Attribute names must be valid iframe attribute names. Whitespace/control characters, HTML syntax characters, and `on*` event-handler attributes are rejected.
+
 ### Adding Custom Providers
 
 You can add your own custom providers in several ways:

--- a/src/Object/MediaObject.php
+++ b/src/Object/MediaObject.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MediaEmbed\Object;
 
+use InvalidArgumentException;
 use MediaEmbed\Template\TemplateResolver;
 
 /**
@@ -232,13 +233,26 @@ class MediaObject implements ObjectInterface {
 	public function setAttribute(array|string $param, string|int|bool|null $value = null) {
 		if (is_array($param)) {
 			foreach ($param as $p => $v) {
+				$this->assertValidAttributeName((string)$p);
 				$this->iframeAttributes[$p] = $v;
 			}
 		} else {
+			$this->assertValidAttributeName($param);
 			$this->iframeAttributes[$param] = $value;
 		}
 
 		return $this;
+	}
+
+	/**
+	 * @param string $name Attribute name.
+	 * @throws \InvalidArgumentException
+	 * @return void
+	 */
+	protected function assertValidAttributeName(string $name): void {
+		if (!preg_match('/^[^\s"\'=<>\/\x00-\x1F\x7F]+$/', $name) || preg_match('/^on/i', $name)) {
+			throw new InvalidArgumentException(sprintf('Invalid iframe attribute name "%s"', $name));
+		}
 	}
 
 	/**

--- a/tests/MediaEmbedTest.php
+++ b/tests/MediaEmbedTest.php
@@ -2,6 +2,7 @@
 
 namespace MediaEmbed\Test;
 
+use InvalidArgumentException;
 use MediaEmbed\MediaEmbed;
 use MediaEmbed\Object\MediaObject;
 use MediaEmbed\Provider\ProviderConfig;
@@ -255,6 +256,44 @@ class MediaEmbedTest extends TestCase {
 		$this->assertStringNotContainsString('bar="quoted"', $code);
 		$this->assertSame('//unsafe.example.com/embed/12345?foo=1&bar="quoted"&amp;wmode=transparent', $Object->getEmbedSrc());
 		$this->assertSame('//unsafe.example.com/embed/12345?foo=1&amp;bar=&quot;quoted&quot;&amp;wmode=transparent', $Object->getEmbedSrcForHtml());
+	}
+
+	public function testSetAttributeRejectsInvalidAttributeName(): void {
+		$MediaEmbed = new MediaEmbed();
+		$Object = $MediaEmbed->parseUrl('https://www.youtube.com/watch?v=11111111111');
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid iframe attribute name "x onload"');
+
+		$Object->setAttribute('x onload', 'alert(1)');
+	}
+
+	public function testSetAttributeRejectsEventHandlerAttributeName(): void {
+		$MediaEmbed = new MediaEmbed();
+		$Object = $MediaEmbed->parseUrl('https://www.youtube.com/watch?v=11111111111');
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid iframe attribute name "onload"');
+
+		$Object->setAttribute('onload', 'alert(1)');
+	}
+
+	public function testSetAttributeAllowsDataAndAriaAttributes(): void {
+		$MediaEmbed = new MediaEmbed();
+		$Object = $MediaEmbed->parseUrl('https://www.youtube.com/watch?v=11111111111');
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		$Object->setAttribute([
+			'data-controller' => 'media',
+			'aria-label' => 'Video',
+		]);
+
+		$code = $Object->getEmbedCode();
+
+		$this->assertStringContainsString(' data-controller="media"', $code);
+		$this->assertStringContainsString(' aria-label="Video"', $code);
 	}
 
 	/**


### PR DESCRIPTION
Rejects invalid iframe attribute names before rendering embed HTML.

This prevents whitespace/control-character attribute-name injection and rejects `on*` event-handler attributes, while allowing normal attributes such as `data-*` and `aria-*`.

Local checks: `composer cs-fix && composer cs-check && composer stan && composer test`