### PR TITLE
Reject unsafe oEmbed endpoint URLs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -439,7 +439,7 @@ if ($response !== null) {
     echo $response->providerName;
 
     if ($response->hasHtml()) {
-        echo $response->html; // Ready-to-use embed code
+        echo $response->html; // Raw remote provider HTML
     }
 
     if ($response->hasThumbnail()) {
@@ -455,6 +455,8 @@ $response = $discovery->fetch('https://example.com/oembed?url=...');
 ```
 
 Discovered oEmbed endpoint URLs may be absolute, protocol-relative, root-relative, or path-relative. Relative endpoint URLs are resolved against the source page URL before they are fetched.
+Only public `http` and `https` endpoint URLs are fetched; local/private IP endpoints and unsafe schemes are rejected.
+The returned `html` field is raw remote provider HTML. Only render it for providers you trust, or sanitize it first.
 
 The `OEmbedResponse` provides typed access to all oEmbed fields:
 

--- a/src/OEmbed/OEmbedDiscovery.php
+++ b/src/OEmbed/OEmbedDiscovery.php
@@ -77,6 +77,10 @@ final class OEmbedDiscovery {
 	 * @return \MediaEmbed\OEmbed\OEmbedResponse|null Response or null on failure.
 	 */
 	public function fetch(string $endpointUrl, ?int $maxWidth = null, ?int $maxHeight = null): ?OEmbedResponse {
+		if (!$this->isSafeEndpointUrl($endpointUrl)) {
+			return null;
+		}
+
 		$params = [];
 		if ($maxWidth !== null) {
 			$params['maxwidth'] = $maxWidth;
@@ -135,7 +139,12 @@ final class OEmbedDiscovery {
 		// Decode HTML entities
 		$href = html_entity_decode($href, ENT_QUOTES | ENT_HTML5);
 
-		return $this->resolveEndpointUrl($href, $baseUrl);
+		$url = $this->resolveEndpointUrl($href, $baseUrl);
+		if (!$this->isSafeEndpointUrl($url)) {
+			return null;
+		}
+
+		return $url;
 	}
 
 	/**
@@ -172,6 +181,34 @@ final class OEmbedDiscovery {
 		$directory = rtrim(substr($path, 0, (int)strrpos($path, '/') + 1), '/');
 
 		return $authority . $directory . '/' . $href;
+	}
+
+	/**
+	 * Check if an oEmbed endpoint URL is safe to fetch.
+	 *
+	 * @param string $url Endpoint URL.
+	 * @return bool
+	 */
+	private function isSafeEndpointUrl(string $url): bool {
+		$parts = parse_url($url);
+		if (!is_array($parts) || empty($parts['scheme']) || empty($parts['host'])) {
+			return false;
+		}
+
+		if (!in_array(strtolower($parts['scheme']), ['http', 'https'], true)) {
+			return false;
+		}
+
+		$host = strtolower($parts['host']);
+		if ($host === 'localhost' || str_ends_with($host, '.localhost')) {
+			return false;
+		}
+
+		if (filter_var($host, FILTER_VALIDATE_IP)) {
+			return filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) !== false;
+		}
+
+		return true;
 	}
 
 }

--- a/tests/OEmbed/OEmbedTest.php
+++ b/tests/OEmbed/OEmbedTest.php
@@ -126,6 +126,28 @@ class OEmbedTest extends TestCase {
 		$this->assertNull($endpoint);
 	}
 
+	public function testOEmbedDiscoveryRejectsUnsafeEndpointScheme(): void {
+		$mockClient = $this->createStub(HttpClientInterface::class);
+		$mockClient->method('get')
+			->willReturn('<html><head><link rel="alternate" type="application/json+oembed" href="javascript:alert(1)" /></head></html>');
+
+		$discovery = new OEmbedDiscovery($mockClient);
+		$endpoint = $discovery->discoverEndpoint('https://example.com/page');
+
+		$this->assertNull($endpoint);
+	}
+
+	public function testOEmbedDiscoveryRejectsProtocolRelativeLocalhostEndpoint(): void {
+		$mockClient = $this->createStub(HttpClientInterface::class);
+		$mockClient->method('get')
+			->willReturn('<html><head><link rel="alternate" type="application/json+oembed" href="//localhost/oembed" /></head></html>');
+
+		$discovery = new OEmbedDiscovery($mockClient);
+		$endpoint = $discovery->discoverEndpoint('https://example.com/page');
+
+		$this->assertNull($endpoint);
+	}
+
 	public function testOEmbedDiscoveryFetch(): void {
 		$mockClient = $this->createStub(HttpClientInterface::class);
 		$mockClient->method('get')
@@ -142,6 +164,18 @@ class OEmbedTest extends TestCase {
 		$this->assertNotNull($response);
 		$this->assertSame('video', $response->type);
 		$this->assertSame('Mock Video', $response->title);
+	}
+
+	public function testOEmbedDiscoveryFetchRejectsUnsafeEndpoint(): void {
+		$mockClient = $this->createMock(HttpClientInterface::class);
+		$mockClient->expects($this->never())
+			->method('get');
+
+		$discovery = new OEmbedDiscovery($mockClient);
+
+		$this->assertNull($discovery->fetch('file:///tmp/oembed.json'));
+		$this->assertNull($discovery->fetch('http://127.0.0.1/oembed'));
+		$this->assertNull($discovery->fetch('http://10.0.0.1/oembed'));
 	}
 
 	public function testOEmbedDiscoveryFetchWithDimensions(): void {


### PR DESCRIPTION
Rejects unsafe oEmbed endpoint URLs before fetching.

Only public `http` and `https` endpoints are accepted. Unsafe schemes, missing hosts, localhost, and private/reserved IP endpoints are rejected for both discovered and direct fetch URLs. Docs now also call out that oEmbed HTML is raw remote provider HTML.

Local checks: `composer cs-fix && composer cs-check && composer stan && composer test`