### PR TITLE
Add top-level cache configuration

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -41,6 +41,7 @@ If you have custom providers using these keys, remove them.
 - `ProviderConfig::$embedHeight` - Now accepts `int|string` (was `string`)
 - `UrlMatcher` cache arguments now accept `Psr\SimpleCache\CacheInterface`
 - `MediaEmbed\Cache\CacheInterface` now extends PSR-16 and includes multi-key cache methods
+- `MediaEmbed::__construct()` accepts optional `cache` and `cacheTtl` arguments
 
 The `fromArray()` method preserves legacy array values as strings, including percentage dimensions such as `100%`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -404,8 +404,7 @@ use MediaEmbed\Cache\ArrayCache;
 // The built-in ArrayCache is in-memory and lasts for the current request only.
 $cache = new ArrayCache();
 $MediaEmbed = new MediaEmbed();
-$matcher = $MediaEmbed->getUrlMatcher();
-$matcher->setCache($cache);
+$MediaEmbed->setCache($cache);
 
 // The domain index will be cached after first match
 $MediaEmbed->parseUrl('https://youtube.com/watch?v=abc');
@@ -417,10 +416,10 @@ For persistent caching, pass any PSR-16 cache implementation (Redis, Memcached, 
 use Psr\SimpleCache\CacheInterface;
 
 /** @var CacheInterface $yourPsr16Cache */
-$MediaEmbed->getUrlMatcher()->setCache($yourPsr16Cache, ttl: 3600);
+$MediaEmbed = new MediaEmbed(cache: $yourPsr16Cache, cacheTtl: 3600);
 ```
 
-The cache stores the generated provider domain index under an internal key. It is invalidated automatically when `UrlMatcher::setProviders()` is called. The `ttl` argument controls how long persistent caches may retain the index.
+The cache stores the generated provider domain index under an internal key. It is invalidated automatically when providers change. The `cacheTtl` argument controls how long persistent caches may retain the index.
 
 ### oEmbed Discovery
 

--- a/src/MediaEmbed.php
+++ b/src/MediaEmbed.php
@@ -15,6 +15,7 @@ use MediaEmbed\Provider\PhpFileLoader;
 use MediaEmbed\Provider\ProviderCollection;
 use MediaEmbed\Provider\ProviderConfig;
 use MediaEmbed\Provider\ProviderLoaderInterface;
+use Psr\SimpleCache\CacheInterface;
 use URLify;
 
 /**
@@ -58,6 +59,16 @@ class MediaEmbed {
 	protected ?UrlMatcher $urlMatcher = null;
 
 	/**
+	 * Optional cache for the URL matcher domain index.
+	 */
+	protected ?CacheInterface $cache = null;
+
+	/**
+	 * URL matcher cache TTL in seconds.
+	 */
+	protected int $cacheTtl = 3600;
+
+	/**
 	 * Get the HTTP client.
 	 *
 	 * @return \MediaEmbed\Http\HttpClientInterface
@@ -85,14 +96,20 @@ class MediaEmbed {
 	 * @param string|null $stubsPath
 	 * @param \MediaEmbed\Http\HttpClientInterface|null $httpClient
 	 * @param \MediaEmbed\Provider\ProviderLoaderInterface|null $providerLoader
+	 * @param \Psr\SimpleCache\CacheInterface|null $cache
+	 * @param int $cacheTtl
 	 */
 	public function __construct(
 		array $config = [],
 		?string $stubsPath = null,
 		?HttpClientInterface $httpClient = null,
 		?ProviderLoaderInterface $providerLoader = null,
+		?CacheInterface $cache = null,
+		int $cacheTtl = 3600,
 	) {
 		$this->httpClient = $httpClient ?? new StreamHttpClient();
+		$this->cache = $cache;
+		$this->cacheTtl = $cacheTtl;
 
 		// Use provided loader or default to PhpFileLoader
 		if ($providerLoader !== null) {
@@ -239,10 +256,25 @@ class MediaEmbed {
 	 */
 	public function getUrlMatcher(): UrlMatcher {
 		if ($this->urlMatcher === null) {
-			$this->urlMatcher = new UrlMatcher($this->providers);
+			$this->urlMatcher = new UrlMatcher($this->providers, $this->cache, $this->cacheTtl);
 		}
 
 		return $this->urlMatcher;
+	}
+
+	/**
+	 * Set the cache used by the URL matcher.
+	 *
+	 * @param \Psr\SimpleCache\CacheInterface|null $cache Cache implementation.
+	 * @param int $ttl Cache TTL in seconds.
+	 * @return $this
+	 */
+	public function setCache(?CacheInterface $cache, int $ttl = 3600) {
+		$this->cache = $cache;
+		$this->cacheTtl = $ttl;
+		$this->urlMatcher = null;
+
+		return $this;
 	}
 
 	/**

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -6,6 +6,8 @@ use DateInterval;
 use MediaEmbed\Cache\ArrayCache;
 use MediaEmbed\Cache\CacheInterface;
 use MediaEmbed\Matcher\UrlMatcher;
+use MediaEmbed\MediaEmbed;
+use MediaEmbed\Provider\ProviderConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\SimpleCache\CacheInterface as PsrCacheInterface;
 
@@ -198,6 +200,36 @@ class CacheTest extends TestCase {
 		], $cache);
 
 		$result = $matcher->match('https://test.example.com/video/123');
+
+		$this->assertNotNull($result);
+		$this->assertTrue($cache->has('media_embed_domain_index'));
+	}
+
+	public function testMediaEmbedUsesConstructorCache(): void {
+		$cache = new ArrayCache();
+		$mediaEmbed = new MediaEmbed(cache: $cache);
+
+		$result = $mediaEmbed->parseUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+
+		$this->assertNotNull($result);
+		$this->assertTrue($cache->has('media_embed_domain_index'));
+	}
+
+	public function testMediaEmbedCacheSurvivesProviderChanges(): void {
+		$cache = new ArrayCache();
+		$mediaEmbed = new MediaEmbed();
+		$mediaEmbed->setCache($cache);
+
+		$mediaEmbed->addProviderConfig(new ProviderConfig(
+			name: 'CacheProvider',
+			website: 'https://cache.example.com',
+			urlMatch: 'https://cache\\.example\\.com/video/([0-9]+)',
+			embedWidth: 640,
+			embedHeight: 360,
+			iframePlayer: '//cache.example.com/embed/$2',
+		));
+
+		$result = $mediaEmbed->parseUrl('https://cache.example.com/video/123');
 
 		$this->assertNotNull($result);
 		$this->assertTrue($cache->has('media_embed_domain_index'));


### PR DESCRIPTION
Adds top-level cache configuration to `MediaEmbed`.

`MediaEmbed` can now receive a PSR-16 cache via constructor or `setCache()`, and recreated URL matchers keep that cache configuration after provider changes.

Local checks: `composer cs-fix && composer cs-check && composer stan && composer test`