### PR TITLE
Preserve extra provider config metadata

### DIFF
--- a/src/Provider/ProviderConfig.php
+++ b/src/Provider/ProviderConfig.php
@@ -27,6 +27,7 @@ final class ProviderConfig {
 	 * @param string|null $fetchMatch Secondary HTTP fetch regex.
 	 * @param bool $supportsTimestamp Whether provider supports timestamps.
 	 * @param string|null $timestampParam Embed query parameter for timestamp values.
+	 * @param array<string, mixed> $extra Extra provider metadata.
 	 */
 	public function __construct(
 		public readonly string $name,
@@ -41,6 +42,7 @@ final class ProviderConfig {
 		public readonly ?string $fetchMatch = null,
 		public readonly bool $supportsTimestamp = false,
 		public readonly ?string $timestampParam = null,
+		public readonly array $extra = [],
 	) {
 	}
 
@@ -69,6 +71,21 @@ final class ProviderConfig {
 			throw ProviderConfigException::missingField('embed-height', $data);
 		}
 
+		$knownKeys = [
+			'name',
+			'website',
+			'url-match',
+			'embed-width',
+			'embed-height',
+			'slug',
+			'iframe-player',
+			'image-src',
+			'id',
+			'fetch-match',
+			'supports-timestamp',
+			'timestamp-param',
+		];
+
 		return new self(
 			name: $data['name'],
 			website: $data['website'],
@@ -82,6 +99,7 @@ final class ProviderConfig {
 			fetchMatch: $data['fetch-match'] ?? null,
 			supportsTimestamp: !empty($data['supports-timestamp']),
 			timestampParam: $data['timestamp-param'] ?? null,
+			extra: array_diff_key($data, array_flip($knownKeys)),
 		);
 	}
 
@@ -98,6 +116,7 @@ final class ProviderConfig {
 			'embed-width' => $this->embedWidth,
 			'embed-height' => $this->embedHeight,
 		];
+		$array += $this->extra;
 
 		if ($this->slug !== null) {
 			$array['slug'] = $this->slug;

--- a/tests/Provider/ProviderConfigTest.php
+++ b/tests/Provider/ProviderConfigTest.php
@@ -70,6 +70,31 @@ class ProviderConfigTest extends TestCase {
 		$this->assertSame('400', $config->embedHeight);
 	}
 
+	public function testFromArrayPreservesExtraProviderMetadata(): void {
+		$data = [
+			'name' => 'ExtraProvider',
+			'website' => 'https://extra.example.com',
+			'url-match' => 'extra\\.example\\.com/([a-z0-9]+)',
+			'embed-width' => '640',
+			'embed-height' => '360',
+			'iframe-player' => '//extra.example.com/embed/$2',
+			'replace' => [
+				'foo' => 'bar',
+			],
+			'status' => 'legacy',
+		];
+
+		$config = ProviderConfig::fromArray($data);
+		$array = $config->toArray();
+
+		$this->assertSame([
+			'foo' => 'bar',
+		], $config->extra['replace']);
+		$this->assertSame('legacy', $config->extra['status']);
+		$this->assertSame($data['replace'], $array['replace']);
+		$this->assertSame('legacy', $array['status']);
+	}
+
 	public function testFromArrayMissingName(): void {
 		$this->expectException(ProviderConfigException::class);
 
@@ -124,6 +149,26 @@ class ProviderConfigTest extends TestCase {
 		$this->assertArrayNotHasKey('slug', $array);
 		$this->assertArrayNotHasKey('supports-timestamp', $array);
 		$this->assertArrayNotHasKey('timestamp-param', $array);
+	}
+
+	public function testToArrayTypedFieldsWinOverExtraFields(): void {
+		$config = new ProviderConfig(
+			name: 'Test',
+			website: 'https://test.com',
+			urlMatch: 'pattern',
+			embedWidth: 640,
+			embedHeight: 360,
+			iframePlayer: '//test.com/embed/$2',
+			extra: [
+				'name' => 'Wrong',
+				'status' => 'legacy',
+			],
+		);
+
+		$array = $config->toArray();
+
+		$this->assertSame('Test', $array['name']);
+		$this->assertSame('legacy', $array['status']);
 	}
 
 	public function testGetUrlMatchPatterns(): void {


### PR DESCRIPTION
This keeps unknown provider metadata keys round-trippable through ProviderConfig::fromArray() and ProviderConfig::toArray().

This matters for provider metadata such as `status`, `replace`, caveats, docs annotations, or future fields that should not be silently discarded by typed config handling.

Local checks:
- `composer cs-fix`
- `composer cs-check`
- `composer test`
- `composer stan`
- `composer validate-providers`