### PR TITLE
Harden provider URL template validation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -259,6 +259,8 @@ For array-based configs (legacy format):
 
 **Note:** In regex patterns and templates, `$1` is the full matched URL, `$2` is the first capture group, `$3` is the second, etc.
 
+Provider templates must use valid `$1`, `$2`, ... placeholders and absolute HTTP(S) URLs. Protocol-relative URLs such as `//www.youtube.com/embed/$2` are supported for iframe and image templates. Run `composer validate-providers` after changing provider data to catch invalid regex patterns, unsafe URL schemes, relative template URLs, duplicate slugs, and malformed placeholders.
+
 ## Advanced Usage
 
 ### Exception-Based Error Handling

--- a/src/Provider/ProviderValidator.php
+++ b/src/Provider/ProviderValidator.php
@@ -38,6 +38,7 @@ final class ProviderValidator {
 			$this->validateRequiredFields($provider, $label, $errors);
 			$this->validateDimensions($provider, $label, $errors);
 			$this->validateUrlMatches($provider, $label, $errors);
+			$this->validateUrlTemplates($provider, $label, $errors);
 			$this->validateFetchMatch($provider, $label, $errors);
 			$this->validateSlug($provider, $label, $slugs, $errors);
 		}
@@ -130,6 +131,74 @@ final class ProviderValidator {
 		}
 
 		$this->validateRegex($provider['fetch-match'], $label, 'fetch-match', $errors);
+	}
+
+	/**
+	 * @param array<string, mixed> $provider
+	 * @param string $label
+	 * @param array<string> $errors
+	 * @return void
+	 */
+	private function validateUrlTemplates(array $provider, string $label, array &$errors): void {
+		foreach (['website', 'iframe-player', 'image-src'] as $field) {
+			if (!array_key_exists($field, $provider)) {
+				continue;
+			}
+
+			if (!is_string($provider[$field]) || $provider[$field] === '') {
+				$errors[] = $label . ': field "' . $field . '" must be a non-empty URL string';
+
+				continue;
+			}
+
+			$this->validateTemplatePlaceholders($provider[$field], $label, $field, $errors);
+			$this->validateTemplateUrl($provider[$field], $label, $field, $errors);
+		}
+	}
+
+	/**
+	 * @param string $template
+	 * @param string $label
+	 * @param string $field
+	 * @param array<string> $errors
+	 * @return void
+	 */
+	private function validateTemplatePlaceholders(string $template, string $label, string $field, array &$errors): void {
+		if (preg_match('/\\$0(?:\\D|$)/', $template) !== 1) {
+			return;
+		}
+
+		$errors[] = $label . ': field "' . $field . '" contains an invalid placeholder';
+	}
+
+	/**
+	 * @param string $template
+	 * @param string $label
+	 * @param string $field
+	 * @param array<string> $errors
+	 * @return void
+	 */
+	private function validateTemplateUrl(string $template, string $label, string $field, array &$errors): void {
+		$url = preg_replace('/\\$[1-9][0-9]*/', 'placeholder', $template);
+		if ($url === null) {
+			$errors[] = $label . ': field "' . $field . '" must be an absolute http(s) URL';
+
+			return;
+		}
+
+		if (str_starts_with($url, '//')) {
+			$url = 'https:' . $url;
+		}
+
+		$parts = parse_url($url);
+		$scheme = is_array($parts) ? ($parts['scheme'] ?? null) : null;
+		$host = is_array($parts) ? ($parts['host'] ?? null) : null;
+
+		if (($scheme === 'http' || $scheme === 'https') && is_string($host) && $host !== '') {
+			return;
+		}
+
+		$errors[] = $label . ': field "' . $field . '" must be an absolute http(s) URL';
 	}
 
 	/**

--- a/tests/Provider/ProviderValidatorTest.php
+++ b/tests/Provider/ProviderValidatorTest.php
@@ -23,12 +23,13 @@ class ProviderValidatorTest extends TestCase {
 				'url-match' => ['broken\\.example\\.com/([0-9]+', ''],
 				'embed-width' => [],
 				'embed-height' => '360',
-				'iframe-player' => '',
+				'iframe-player' => 'javascript:alert($2)',
+				'image-src' => '//broken.example.com/thumb/$0.jpg',
 				'fetch-match' => '(',
 			],
 			[
 				'name' => 'Broken',
-				'website' => 'https://other.example.com',
+				'website' => '/relative',
 				'url-match' => 'other\\.example\\.com/([0-9]+)',
 				'embed-width' => 640,
 				'embed-height' => 360,
@@ -39,12 +40,32 @@ class ProviderValidatorTest extends TestCase {
 		$validator = new ProviderValidator();
 		$errors = $validator->validate($providers);
 
-		$this->assertContains('Broken: missing required field "iframe-player"', $errors);
 		$this->assertContains('Broken: field "embed-width" must be an integer or string', $errors);
 		$this->assertContains('Broken: invalid regex in "url-match"', $errors);
 		$this->assertContains('Broken: url-match entries must be non-empty strings', $errors);
+		$this->assertContains('Broken: field "iframe-player" must be an absolute http(s) URL', $errors);
+		$this->assertContains('Broken: field "image-src" contains an invalid placeholder', $errors);
+		$this->assertContains('Broken: field "website" must be an absolute http(s) URL', $errors);
 		$this->assertContains('Broken: invalid regex in "fetch-match"', $errors);
 		$this->assertContains('Broken: duplicate slug "broken" already used by Broken', $errors);
+	}
+
+	public function testValidateReportsNonStringTemplateFields(): void {
+		$providers = [
+			[
+				'name' => 'Broken',
+				'website' => ['https://broken.example.com'],
+				'url-match' => 'broken\\.example\\.com/([0-9]+)',
+				'embed-width' => 640,
+				'embed-height' => 360,
+				'iframe-player' => '//broken.example.com/embed/$2',
+			],
+		];
+
+		$validator = new ProviderValidator();
+		$errors = $validator->validate($providers);
+
+		$this->assertContains('Broken: field "website" must be a non-empty URL string', $errors);
 	}
 
 }


### PR DESCRIPTION
This expands provider validation to catch unsafe or malformed URL templates before provider data reaches runtime.

It now validates `website`, `iframe-player`, and `image-src` as absolute HTTP(S) URLs, allows protocol-relative embed assets, and rejects invalid `$0` placeholders. The provider docs now mention these validation rules for custom provider authors.

Local checks:
- `composer cs-fix`
- `composer cs-check`
- `composer test`
- `composer stan`
- `composer validate-providers`