### PR TITLE
Tighten URL and oEmbed discovery parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [![CI](https://github.com/dereuromark/media-embed/workflows/CI/badge.svg)](https://github.com/dereuromark/media-embed/actions?query=workflow%3ACI+branch%3Amaster)
 [![PHPStan](https://img.shields.io/badge/PHPStan-level%208-brightgreen.svg?style=flat)](https://phpstan.org/)
 [![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%208.1-8892BF.svg)](https://www.php.net/)
-[![License](https://poser.pugx.org/dereuromark/media-embed/license.svg)](LICENSE)
-[![Latest Stable Version](https://poser.pugx.org/dereuromark/media-embed/v/stable.svg)](https://packagist.org/packages/dereuromark/media-embed)
-[![Total Downloads](https://poser.pugx.org/dereuromark/media-embed/d/total.svg)](https://packagist.org/packages/dereuromark/media-embed)
+[![License](https://img.shields.io/packagist/l/dereuromark/media-embed.svg)](LICENSE)
+[![Latest Stable Version](https://img.shields.io/packagist/v/dereuromark/media-embed.svg)](https://packagist.org/packages/dereuromark/media-embed)
+[![Total Downloads](https://img.shields.io/packagist/dt/dereuromark/media-embed.svg)](https://packagist.org/packages/dereuromark/media-embed)
 [![Coding Standards](https://img.shields.io/badge/cs-PSR--2--R-yellow.svg)](https://github.com/php-fig-rectified/fig-rectified-standards)
 
 A utility library that generates HTML embed tags for audio or video located on a given URL.

--- a/src/Matcher/UrlMatcher.php
+++ b/src/Matcher/UrlMatcher.php
@@ -101,6 +101,11 @@ final class UrlMatcher {
 	 * @return \MediaEmbed\Matcher\MatchResult|null Match result or null if no match.
 	 */
 	public function match(string $url): ?MatchResult {
+		$url = $this->normalizeUrl($url);
+		if ($url === null) {
+			return null;
+		}
+
 		$this->buildIndexIfNeeded();
 
 		// Try fast path first using domain index
@@ -114,6 +119,31 @@ final class UrlMatcher {
 
 		// Fall back to checking all providers
 		return $this->matchAgainstProviders($url, array_keys($this->providers));
+	}
+
+	/**
+	 * Normalize and validate a URL before matching.
+	 *
+	 * @param string $url The URL to normalize.
+	 * @return string|null
+	 */
+	private function normalizeUrl(string $url): ?string {
+		$url = trim($url);
+		if ($url === '' || preg_match('/\\s/', $url)) {
+			return null;
+		}
+
+		$parsed = parse_url($url);
+		if (!is_array($parsed) || empty($parsed['scheme']) || empty($parsed['host'])) {
+			return null;
+		}
+
+		$scheme = strtolower($parsed['scheme']);
+		if ($scheme !== 'http' && $scheme !== 'https') {
+			return null;
+		}
+
+		return $url;
 	}
 
 	/**

--- a/src/OEmbed/OEmbedDiscovery.php
+++ b/src/OEmbed/OEmbedDiscovery.php
@@ -117,34 +117,54 @@ final class OEmbedDiscovery {
 	 * @return string|null The oEmbed URL or null if not found.
 	 */
 	private function parseOEmbedLink(string $html, string $baseUrl): ?string {
-		// Match link tags with oembed type
-		$pattern = '/<link[^>]+type=["\']application\/json\+oembed["\'][^>]*>/i';
-		if (!preg_match($pattern, $html, $match)) {
-			// Try alternate pattern with type before rel
-			$pattern = '/<link[^>]+rel=["\']alternate["\'][^>]+type=["\']application\/json\+oembed["\'][^>]*>/i';
-			if (!preg_match($pattern, $html, $match)) {
+		if (!preg_match_all('/<link\\s+[^>]*>/i', $html, $matches)) {
+			return null;
+		}
+
+		foreach ($matches[0] as $linkTag) {
+			$attributes = $this->parseLinkAttributes($linkTag);
+			$rel = strtolower($attributes['rel'] ?? '');
+			$relTokens = preg_split('/\\s+/', $rel, -1, PREG_SPLIT_NO_EMPTY);
+
+			if (!in_array('alternate', $relTokens ?: [], true)) {
+				continue;
+			}
+			if (strtolower($attributes['type'] ?? '') !== 'application/json+oembed') {
+				continue;
+			}
+			if (empty($attributes['href'])) {
+				continue;
+			}
+
+			$href = html_entity_decode($attributes['href'], ENT_QUOTES | ENT_HTML5);
+			$url = $this->resolveEndpointUrl($href, $baseUrl);
+			if (!$this->isSafeEndpointUrl($url)) {
 				return null;
 			}
+
+			return $url;
 		}
 
-		$linkTag = $match[0];
+		return null;
+	}
 
-		// Extract href attribute
-		if (!preg_match('/href=["\']([^"\']+)["\']/i', $linkTag, $hrefMatch)) {
-			return null;
+	/**
+	 * Parse quoted attributes from a link tag.
+	 *
+	 * @param string $linkTag Link tag HTML.
+	 * @return array<string, string>
+	 */
+	private function parseLinkAttributes(string $linkTag): array {
+		if (!preg_match_all('/([a-z][a-z0-9:_-]*)\\s*=\\s*([\'"])(.*?)\\2/is', $linkTag, $matches, PREG_SET_ORDER)) {
+			return [];
 		}
 
-		$href = $hrefMatch[1];
-
-		// Decode HTML entities
-		$href = html_entity_decode($href, ENT_QUOTES | ENT_HTML5);
-
-		$url = $this->resolveEndpointUrl($href, $baseUrl);
-		if (!$this->isSafeEndpointUrl($url)) {
-			return null;
+		$attributes = [];
+		foreach ($matches as $match) {
+			$attributes[strtolower($match[1])] = $match[3];
 		}
 
-		return $url;
+		return $attributes;
 	}
 
 	/**

--- a/tests/MediaEmbedTest.php
+++ b/tests/MediaEmbedTest.php
@@ -128,6 +128,20 @@ class MediaEmbedTest extends TestCase {
 		$this->assertNull($result);
 	}
 
+	public function testParseUrlRejectsTextContainingSupportedUrl(): void {
+		$MediaEmbed = new MediaEmbed();
+		$result = $MediaEmbed->parseUrl('Watch https://www.youtube.com/watch?v=yiSjHJnc9CY now');
+
+		$this->assertNull($result);
+	}
+
+	public function testParseUrlRejectsNonHttpUrl(): void {
+		$MediaEmbed = new MediaEmbed();
+		$result = $MediaEmbed->parseUrl('javascript:https://www.youtube.com/watch?v=yiSjHJnc9CY');
+
+		$this->assertNull($result);
+	}
+
 	/**
 	 * @dataProvider getUrls
 	 * @param string $url

--- a/tests/OEmbed/OEmbedTest.php
+++ b/tests/OEmbed/OEmbedTest.php
@@ -82,6 +82,28 @@ class OEmbedTest extends TestCase {
 		$this->assertSame('https://example.com/oembed?url=test', $endpoint);
 	}
 
+	public function testOEmbedDiscoveryParsesCaseInsensitiveAttributesInAnyOrder(): void {
+		$mockClient = $this->createStub(HttpClientInterface::class);
+		$mockClient->method('get')
+			->willReturn('<html><head><link HREF="https://example.com/oembed?url=test" TYPE="application/json+oembed" REL="self alternate" /></head></html>');
+
+		$discovery = new OEmbedDiscovery($mockClient);
+		$endpoint = $discovery->discoverEndpoint('https://example.com/video/123');
+
+		$this->assertSame('https://example.com/oembed?url=test', $endpoint);
+	}
+
+	public function testOEmbedDiscoveryRequiresAlternateRel(): void {
+		$mockClient = $this->createStub(HttpClientInterface::class);
+		$mockClient->method('get')
+			->willReturn('<html><head><link rel="self" type="application/json+oembed" href="https://example.com/oembed?url=test" /></head></html>');
+
+		$discovery = new OEmbedDiscovery($mockClient);
+		$endpoint = $discovery->discoverEndpoint('https://example.com/video/123');
+
+		$this->assertNull($endpoint);
+	}
+
 	public function testOEmbedDiscoveryResolvesRootRelativeEndpoint(): void {
 		$mockClient = $this->createStub(HttpClientInterface::class);
 		$mockClient->method('get')


### PR DESCRIPTION
This tightens URL and oEmbed parsing behavior before the next major release.

Changes:
- Reject non-standalone URLs in `parseUrl()` so arbitrary text containing a supported URL is not treated as a valid media URL.
- Require HTTP(S) URLs before provider matching.
- Parse oEmbed link attributes explicitly so discovery handles attribute casing/order and multi-token `rel` values.
- Require `rel=alternate` for JSON oEmbed links instead of accepting any link with the oEmbed content type.

Local checks:
- `composer cs-fix`
- `composer cs-check`
- `composer test`
- `composer stan`
- `composer validate-providers`