### PR TITLE
Add generated docs drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ steps.composercache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ steps.key-date.outputs.date }}-${{ hashFiles('composer.json') }}-${{ matrix.prefer-lowest }}
+          key: ${{ runner.os }}-composer-${{ matrix.php-version }}-${{ matrix.prefer-lowest }}-${{ hashFiles('composer.json', 'composer.lock') }}
 
       - name: Composer install --no-progress --prefer-dist --optimize-autoloader
         run: |
@@ -84,10 +84,12 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ steps.composercache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ steps.key-date.outputs.date }}-${{ hashFiles('composer.json') }}-${{ matrix.prefer-lowest }}
+          key: ${{ runner.os }}-composer-validation-${{ hashFiles('composer.json', 'composer.lock') }}
 
       - name: Install PHPStan
-        run: composer stan-setup
+        run: |
+          composer validate --strict
+          composer stan-setup
 
       - name: Run PHPStan
         run: composer stan
@@ -97,6 +99,9 @@ jobs:
 
       - name: Validate providers
         run: composer validate-providers
+
+      - name: Check generated docs
+        run: bin/generate-docs -d
 
       - name: Run link checker
         run: |

--- a/docs/README.md
+++ b/docs/README.md
@@ -573,6 +573,14 @@ See [wiki](https://github.com/dereuromark/media-embed/wiki).
 Looking forward for contributions, e.g. adding more yet missing services etc.
 Please provide a simple test URL and test case for any new service.
 
+Provider change checklist:
+
+- Add at least one fixture URL for each non-fetch `url-match` pattern.
+- Add a mocked HTTP test for providers using `fetch-match`.
+- Run `composer validate-providers` after editing provider data.
+- Run `bin/generate-docs` and commit any `docs/supported.md` changes.
+- Confirm generated iframe URLs still match the provider's current embed documentation.
+
 Run tests with
 ```
 composer test


### PR DESCRIPTION
This tightens CI and provider contribution docs for the next release.

Changes:
- Fix Composer cache keys that referenced undefined workflow values.
- Add `composer validate --strict` to validation setup.
- Add `bin/generate-docs -d` to CI so `docs/supported.md` cannot drift from provider data.
- Document a provider change checklist covering fixtures, fetch-provider mocks, provider validation, docs generation, and embed URL verification.

Local checks:
- `composer cs-fix`
- `composer cs-check`
- `composer test`
- `composer stan`
- `composer validate --strict`
- `composer validate-providers`
- `bin/generate-docs -d`