### PR TITLE
Add provider-specific iframe params

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -109,6 +109,21 @@ This should return an embed code like:
 
 Attribute names must be valid iframe attribute names. Whitespace/control characters, HTML syntax characters, and `on*` event-handler attributes are rejected.
 
+Provider-specific iframe params can also be configured once when constructing `MediaEmbed`. This is useful for providers such as Twitch that require a domain-specific `parent` query parameter:
+
+```php
+$MediaEmbed = new MediaEmbed([
+    'provider_params' => [
+        'twitch-video' => [
+            'parent' => 'example.com',
+        ],
+        'twitch-clip' => [
+            'parent' => 'example.com',
+        ],
+    ],
+]);
+```
+
 ### Adding Custom Providers
 
 You can add your own custom providers in several ways:
@@ -239,6 +254,9 @@ $config = new ProviderConfig(
     imageSrc: '//.../$2.jpg',     // Optional: Thumbnail URL template
     supportsTimestamp: false,     // Optional: Timestamp support (like YouTube)
     timestampParam: 'start',      // Optional: Embed query parameter for timestamps
+    iframeParams: [               // Optional: Default iframe query parameters
+        'parent' => 'example.com',
+    ],
 );
 ```
 
@@ -256,6 +274,7 @@ For array-based configs (legacy format):
 - **fetch-match**: Optional regex for secondary HTTP lookup
 - **supports-timestamp**: Optional timestamp support flag
 - **timestamp-param**: Optional embed query parameter for timestamp values
+- **iframe-params**: Optional default iframe query parameters
 
 **Note:** In regex patterns and templates, `$1` is the full matched URL, `$2` is the first capture group, `$3` is the second, etc.
 

--- a/src/Object/MediaObject.php
+++ b/src/Object/MediaObject.php
@@ -474,6 +474,12 @@ class MediaObject implements ObjectInterface {
 		$this->iframeParams = [
 			'wmode' => 'transparent',
 		];
+		if (!empty($stub['iframe-params']) && is_array($stub['iframe-params'])) {
+			$this->iframeParams += $stub['iframe-params'];
+		}
+		if (!empty($stub['slug']) && !empty($this->config['provider_params'][$stub['slug']]) && is_array($this->config['provider_params'][$stub['slug']])) {
+			$this->iframeParams = $this->config['provider_params'][$stub['slug']] + $this->iframeParams;
+		}
 		$this->iframeAttributes = [
 			'type' => 'text/html',
 			'width' => $stub['embed-width'],

--- a/src/Provider/ProviderConfig.php
+++ b/src/Provider/ProviderConfig.php
@@ -27,6 +27,7 @@ final class ProviderConfig {
 	 * @param string|null $fetchMatch Secondary HTTP fetch regex.
 	 * @param bool $supportsTimestamp Whether provider supports timestamps.
 	 * @param string|null $timestampParam Embed query parameter for timestamp values.
+	 * @param array<string, mixed> $iframeParams Default iframe query parameters.
 	 * @param array<string, mixed> $extra Extra provider metadata.
 	 */
 	public function __construct(
@@ -42,6 +43,7 @@ final class ProviderConfig {
 		public readonly ?string $fetchMatch = null,
 		public readonly bool $supportsTimestamp = false,
 		public readonly ?string $timestampParam = null,
+		public readonly array $iframeParams = [],
 		public readonly array $extra = [],
 	) {
 	}
@@ -84,6 +86,7 @@ final class ProviderConfig {
 			'fetch-match',
 			'supports-timestamp',
 			'timestamp-param',
+			'iframe-params',
 		];
 
 		return new self(
@@ -99,6 +102,7 @@ final class ProviderConfig {
 			fetchMatch: $data['fetch-match'] ?? null,
 			supportsTimestamp: !empty($data['supports-timestamp']),
 			timestampParam: $data['timestamp-param'] ?? null,
+			iframeParams: !empty($data['iframe-params']) && is_array($data['iframe-params']) ? $data['iframe-params'] : [],
 			extra: array_diff_key($data, array_flip($knownKeys)),
 		);
 	}
@@ -138,6 +142,9 @@ final class ProviderConfig {
 		}
 		if ($this->timestampParam !== null) {
 			$array['timestamp-param'] = $this->timestampParam;
+		}
+		if ($this->iframeParams) {
+			$array['iframe-params'] = $this->iframeParams;
 		}
 
 		return $array;

--- a/tests/MediaEmbedTest.php
+++ b/tests/MediaEmbedTest.php
@@ -340,6 +340,68 @@ class MediaEmbedTest extends TestCase {
 		$this->assertStringNotContainsString(' hidden', $code);
 	}
 
+	public function testProviderDefaultIframeParams(): void {
+		$MediaEmbed = new MediaEmbed();
+		$MediaEmbed->addProviderConfig(new ProviderConfig(
+			name: 'ParamProvider',
+			website: 'https://param.example.com',
+			urlMatch: 'https://param\\.example\\.com/video/([0-9]+)',
+			embedWidth: 640,
+			embedHeight: 360,
+			iframePlayer: '//param.example.com/embed/$2',
+			iframeParams: [
+				'parent' => 'example.com',
+			],
+		));
+
+		$Object = $MediaEmbed->parseUrl('https://param.example.com/video/12345');
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		$this->assertStringContainsString('parent=example.com', $Object->getEmbedSrc());
+	}
+
+	public function testConfiguredProviderParamsOverrideDefaults(): void {
+		$MediaEmbed = new MediaEmbed([
+			'provider_params' => [
+				'paramprovider' => [
+					'parent' => 'configured.example.com',
+				],
+			],
+		]);
+		$MediaEmbed->addProviderConfig(new ProviderConfig(
+			name: 'ParamProvider',
+			website: 'https://param.example.com',
+			urlMatch: 'https://param\\.example\\.com/video/([0-9]+)',
+			embedWidth: 640,
+			embedHeight: 360,
+			iframePlayer: '//param.example.com/embed/$2',
+			iframeParams: [
+				'parent' => 'default.example.com',
+			],
+		));
+
+		$Object = $MediaEmbed->parseUrl('https://param.example.com/video/12345');
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		$this->assertStringContainsString('parent=configured.example.com', $Object->getEmbedSrc());
+		$this->assertStringNotContainsString('parent=default.example.com', $Object->getEmbedSrc());
+	}
+
+	public function testTwitchParentParamCanBeConfigured(): void {
+		$MediaEmbed = new MediaEmbed([
+			'provider_params' => [
+				'twitch-video' => [
+					'parent' => 'example.com',
+				],
+			],
+		]);
+
+		$Object = $MediaEmbed->parseUrl('https://www.twitch.tv/videos/293684811');
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		$this->assertStringContainsString('parent=example.com', $Object->getEmbedSrc());
+	}
+
 	public function testEmbedCodeEscapesIframeSource(): void {
 		$MediaEmbed = new MediaEmbed();
 		$MediaEmbed->addProviderConfig(new ProviderConfig(

--- a/tests/Provider/ProviderConfigTest.php
+++ b/tests/Provider/ProviderConfigTest.php
@@ -41,6 +41,9 @@ class ProviderConfigTest extends TestCase {
 			'fetch-match' => 'data-id="([a-z0-9]+)"',
 			'supports-timestamp' => true,
 			'timestamp-param' => 'start',
+			'iframe-params' => [
+				'parent' => 'example.com',
+			],
 		];
 
 		$config = ProviderConfig::fromArray($data);
@@ -52,6 +55,9 @@ class ProviderConfigTest extends TestCase {
 		$this->assertSame('data-id="([a-z0-9]+)"', $config->fetchMatch);
 		$this->assertTrue($config->supportsTimestamp);
 		$this->assertSame('start', $config->timestampParam);
+		$this->assertSame([
+			'parent' => 'example.com',
+		], $config->iframeParams);
 	}
 
 	public function testFromArrayPreservesPercentageDimensions(): void {
@@ -169,6 +175,26 @@ class ProviderConfigTest extends TestCase {
 
 		$this->assertSame('Test', $array['name']);
 		$this->assertSame('legacy', $array['status']);
+	}
+
+	public function testToArrayWithIframeParams(): void {
+		$config = new ProviderConfig(
+			name: 'Test',
+			website: 'https://test.com',
+			urlMatch: 'pattern',
+			embedWidth: 640,
+			embedHeight: 360,
+			iframePlayer: '//test.com/embed/$2',
+			iframeParams: [
+				'parent' => 'example.com',
+			],
+		);
+
+		$array = $config->toArray();
+
+		$this->assertSame([
+			'parent' => 'example.com',
+		], $array['iframe-params']);
 	}
 
 	public function testGetUrlMatchPatterns(): void {


### PR DESCRIPTION
This adds a generic way to configure provider-specific iframe query parameters.

The main use case is Twitch, whose embed URLs require a domain-specific `parent` parameter. Users can now configure this once via `provider_params`, and custom provider configs can declare default `iframe-params` through `ProviderConfig` or array config. Runtime config wins over provider defaults.

Local checks:
- `composer cs-fix`
- `composer cs-check`
- `composer test`
- `composer stan`
- `composer validate-providers`