### PR TITLE
Backport embed hardening fixes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -446,7 +446,7 @@ if ($response !== null) {
     echo $response->providerName;
 
     if ($response->hasHtml()) {
-        echo $response->html; // Ready-to-use embed code
+        echo $response->html; // Raw remote provider HTML
     }
 
     if ($response->hasThumbnail()) {
@@ -460,6 +460,10 @@ $response = $discovery->discover($url, maxWidth: 640, maxHeight: 480);
 // Or fetch directly from a known endpoint
 $response = $discovery->fetch('https://example.com/oembed?url=...');
 ```
+
+Discovered oEmbed endpoint URLs may be absolute, protocol-relative, root-relative, or path-relative. Relative endpoint URLs are resolved against the source page URL before they are fetched.
+Only public `http` and `https` endpoint URLs are fetched; local/private IP endpoints and unsafe schemes are rejected.
+The returned `html` field is raw remote provider HTML. Only render it for providers you trust, or sanitize it first.
 
 The `OEmbedResponse` provides typed access to all oEmbed fields:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -325,6 +325,8 @@ class MockHttpClient implements HttpClientInterface {
 $MediaEmbed = new MediaEmbed([], null, new MockHttpClient());
 ```
 
+The default `StreamHttpClient` only fetches public `http` and `https` URLs, rejects localhost/private literal IP targets, disables redirects, and caps response size. Inject a custom `HttpClientInterface` implementation if you need a different network policy.
+
 ### Provider Loaders
 
 Load providers from different sources using the loader interface:

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,6 +105,8 @@ This should return and embed code like:
 <embed src="https://www.youtube.com/embed/111111?autoplay=1&amp;loop=1" class="iframe-class" data-html5-parameter></iframe>
 ```
 
+Attribute names must be valid iframe attribute names. Whitespace/control characters, HTML syntax characters, and `on*` event-handler attributes are rejected.
+
 ### Adding Custom Providers
 
 You can add your own custom providers in several ways:

--- a/src/Http/StreamHttpClient.php
+++ b/src/Http/StreamHttpClient.php
@@ -18,8 +18,9 @@ class StreamHttpClient implements HttpClientInterface {
 
 	/**
 	 * @param int $timeout Request timeout in seconds.
+	 * @param int $maxBytes Maximum response size in bytes.
 	 */
-	public function __construct(int $timeout = 5) {
+	public function __construct(int $timeout = 5, protected int $maxBytes = 1048576) {
 		$this->timeout = $timeout;
 	}
 
@@ -27,21 +28,60 @@ class StreamHttpClient implements HttpClientInterface {
 	 * @inheritDoc
 	 */
 	public function get(string $url, array $options = []): ?string {
+		if (!$this->isSafeUrl($url)) {
+			return null;
+		}
+
 		$timeout = $options['timeout'] ?? $this->timeout;
+		$maxBytes = $options['max_bytes'] ?? $this->maxBytes;
 
 		$context = stream_context_create([
 			'http' => [
 				'header' => 'Connection: close',
 				'timeout' => $timeout,
+				'follow_location' => 0,
+				'ignore_errors' => false,
 			],
 		]);
 
-		$content = @file_get_contents($url, false, $context);
-		if ($content === false) {
+		$stream = @fopen($url, 'rb', false, $context);
+		if ($stream === false) {
+			return null;
+		}
+
+		$content = stream_get_contents($stream, $maxBytes + 1);
+		fclose($stream);
+		if ($content === false || strlen($content) > $maxBytes) {
 			return null;
 		}
 
 		return $content;
+	}
+
+	/**
+	 * @param string $url URL to validate.
+	 * @return bool
+	 */
+	protected function isSafeUrl(string $url): bool {
+		$parts = parse_url($url);
+		if (!is_array($parts) || empty($parts['scheme']) || empty($parts['host'])) {
+			return false;
+		}
+
+		if (!in_array(strtolower($parts['scheme']), ['http', 'https'], true)) {
+			return false;
+		}
+
+		$host = strtolower($parts['host']);
+		if ($host === 'localhost' || str_ends_with($host, '.localhost')) {
+			return false;
+		}
+
+		if (filter_var($host, FILTER_VALIDATE_IP)) {
+			return filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) !== false;
+		}
+
+		return true;
 	}
 
 }

--- a/src/Matcher/UrlMatcher.php
+++ b/src/Matcher/UrlMatcher.php
@@ -28,6 +28,13 @@ final class UrlMatcher {
 	private array $domainIndex = [];
 
 	/**
+	 * Provider slugs whose URL patterns do not expose a literal domain.
+	 *
+	 * @var array<string>
+	 */
+	private array $unindexedSlugs = [];
+
+	/**
 	 * All providers keyed by slug.
 	 *
 	 * @var array<string, array<string, mixed>>
@@ -70,6 +77,7 @@ final class UrlMatcher {
 		$this->providers = $providers;
 		$this->indexBuilt = false;
 		$this->domainIndex = [];
+		$this->unindexedSlugs = [];
 
 		// Clear cached index when providers change
 		if ($this->cache !== null) {
@@ -100,19 +108,51 @@ final class UrlMatcher {
 	 * @return \MediaEmbed\Matcher\MatchResult|null Match result or null if no match.
 	 */
 	public function match(string $url): ?MatchResult {
+		$url = $this->normalizeUrl($url);
+		if ($url === null) {
+			return null;
+		}
+
 		$this->buildIndexIfNeeded();
 
 		// Try fast path first using domain index
 		$domain = $this->extractDomain($url);
-		if ($domain !== null && isset($this->domainIndex[$domain])) {
-			$result = $this->matchAgainstProviders($url, $this->domainIndex[$domain]);
-			if ($result !== null) {
-				return $result;
-			}
+		if ($domain === null) {
+			return null;
 		}
 
-		// Fall back to checking all providers
-		return $this->matchAgainstProviders($url, array_keys($this->providers));
+		$slugs = $this->domainIndex[$domain] ?? [];
+		$slugs = array_merge($slugs, $this->unindexedSlugs);
+		if (!$slugs) {
+			return null;
+		}
+
+		return $this->matchAgainstProviders($url, $slugs);
+	}
+
+	/**
+	 * Normalize and validate a URL before matching.
+	 *
+	 * @param string $url The URL to normalize.
+	 * @return string|null
+	 */
+	private function normalizeUrl(string $url): ?string {
+		$url = trim($url);
+		if ($url === '' || preg_match('/\\s/', $url)) {
+			return null;
+		}
+
+		$parsed = parse_url($url);
+		if (!is_array($parsed) || empty($parsed['scheme']) || empty($parsed['host'])) {
+			return null;
+		}
+
+		$scheme = strtolower($parsed['scheme']);
+		if ($scheme !== 'http' && $scheme !== 'https') {
+			return null;
+		}
+
+		return $url;
 	}
 
 	/**
@@ -164,6 +204,7 @@ final class UrlMatcher {
 			$cached = $this->cache->get(static::CACHE_KEY);
 			if (is_array($cached)) {
 				$this->domainIndex = $cached;
+				$this->unindexedSlugs = $this->extractUnindexedSlugs();
 				$this->indexBuilt = true;
 
 				return;
@@ -171,13 +212,16 @@ final class UrlMatcher {
 		}
 
 		$this->domainIndex = [];
+		$this->unindexedSlugs = [];
 
 		foreach ($this->providers as $slug => $provider) {
 			$patterns = (array)($provider['url-match'] ?? []);
+			$hasIndexedDomain = false;
 
 			foreach ($patterns as $pattern) {
 				$domains = $this->extractDomainsFromPattern($pattern);
 				foreach ($domains as $domain) {
+					$hasIndexedDomain = true;
 					if (!isset($this->domainIndex[$domain])) {
 						$this->domainIndex[$domain] = [];
 					}
@@ -185,6 +229,10 @@ final class UrlMatcher {
 						$this->domainIndex[$domain][] = $slug;
 					}
 				}
+			}
+
+			if (!$hasIndexedDomain) {
+				$this->unindexedSlugs[] = $slug;
 			}
 		}
 
@@ -245,6 +293,28 @@ final class UrlMatcher {
 		}
 
 		return array_unique($domains);
+	}
+
+	/**
+	 * Extract provider slugs whose URL patterns do not expose a literal domain.
+	 *
+	 * @return array<string>
+	 */
+	private function extractUnindexedSlugs(): array {
+		$slugs = [];
+
+		foreach ($this->providers as $slug => $provider) {
+			$patterns = (array)($provider['url-match'] ?? []);
+			foreach ($patterns as $pattern) {
+				if ($this->extractDomainsFromPattern($pattern)) {
+					continue 2;
+				}
+			}
+
+			$slugs[] = $slug;
+		}
+
+		return $slugs;
 	}
 
 	/**

--- a/src/Matcher/UrlMatcher.php
+++ b/src/Matcher/UrlMatcher.php
@@ -81,7 +81,7 @@ final class UrlMatcher {
 
 		// Clear cached index when providers change
 		if ($this->cache !== null) {
-			$this->cache->delete(static::CACHE_KEY);
+			$this->cache->delete(self::CACHE_KEY);
 		}
 
 		return $this;
@@ -121,13 +121,17 @@ final class UrlMatcher {
 			return null;
 		}
 
-		$slugs = $this->domainIndex[$domain] ?? [];
+		$slugs = $this->slugsForDomain($domain);
 		$slugs = array_merge($slugs, $this->unindexedSlugs);
-		if (!$slugs) {
-			return null;
+		if ($slugs) {
+			$result = $this->matchAgainstProviders($url, $domain, $slugs);
+			if ($result !== null) {
+				return $result;
+			}
 		}
 
-		return $this->matchAgainstProviders($url, $slugs);
+		// Fall back to checking all providers, but reject matches from different hosts.
+		return $this->matchAgainstProviders($url, $domain, array_keys($this->providers));
 	}
 
 	/**
@@ -159,10 +163,11 @@ final class UrlMatcher {
 	 * Match URL against a specific list of provider slugs.
 	 *
 	 * @param string $url The URL to match.
+	 * @param string $domain Normalized input URL domain.
 	 * @param array<string> $slugs Provider slugs to check.
 	 * @return \MediaEmbed\Matcher\MatchResult|null
 	 */
-	private function matchAgainstProviders(string $url, array $slugs): ?MatchResult {
+	private function matchAgainstProviders(string $url, string $domain, array $slugs): ?MatchResult {
 		$checkedSlugs = [];
 
 		foreach ($slugs as $slug) {
@@ -181,12 +186,52 @@ final class UrlMatcher {
 
 			foreach ($patterns as $pattern) {
 				if (preg_match('~' . $pattern . '~imu', $url, $matches)) {
+					if (!$this->matchBelongsToDomain($matches[0], $domain)) {
+						continue;
+					}
+
 					return new MatchResult($slug, $matches, $provider);
 				}
 			}
 		}
 
 		return null;
+	}
+
+	/**
+	 * Get indexed provider slugs that can match a normalized domain.
+	 *
+	 * @param string $domain Normalized input URL domain.
+	 * @return array<string>
+	 */
+	private function slugsForDomain(string $domain): array {
+		$slugs = [];
+
+		foreach ($this->domainIndex as $indexedDomain => $indexedSlugs) {
+			if ($domain !== $indexedDomain && !str_ends_with($domain, '.' . $indexedDomain)) {
+				continue;
+			}
+
+			$slugs = array_merge($slugs, $indexedSlugs);
+		}
+
+		return array_values(array_unique($slugs));
+	}
+
+	/**
+	 * Check that a regex match belongs to the original input URL domain.
+	 *
+	 * @param string $match Matched URL substring.
+	 * @param string $domain Normalized input URL domain.
+	 * @return bool
+	 */
+	private function matchBelongsToDomain(string $match, string $domain): bool {
+		$matchDomain = $this->extractDomain($match);
+		if ($matchDomain === null) {
+			return true;
+		}
+
+		return $matchDomain === $domain;
 	}
 
 	/**
@@ -201,7 +246,7 @@ final class UrlMatcher {
 
 		// Try to load from cache first
 		if ($this->cache !== null) {
-			$cached = $this->cache->get(static::CACHE_KEY);
+			$cached = $this->cache->get(self::CACHE_KEY);
 			if (is_array($cached)) {
 				$this->domainIndex = $cached;
 				$this->unindexedSlugs = $this->extractUnindexedSlugs();
@@ -220,6 +265,12 @@ final class UrlMatcher {
 
 			foreach ($patterns as $pattern) {
 				$domains = $this->extractDomainsFromPattern($pattern);
+				if (!$domains) {
+					$this->unindexedSlugs[] = $slug;
+
+					continue;
+				}
+
 				foreach ($domains as $domain) {
 					$hasIndexedDomain = true;
 					if (!isset($this->domainIndex[$domain])) {
@@ -236,9 +287,11 @@ final class UrlMatcher {
 			}
 		}
 
+		$this->unindexedSlugs = array_values(array_unique($this->unindexedSlugs));
+
 		// Store in cache
 		if ($this->cache !== null) {
-			$this->cache->set(static::CACHE_KEY, $this->domainIndex, $this->cacheTtl);
+			$this->cache->set(self::CACHE_KEY, $this->domainIndex, $this->cacheTtl);
 		}
 
 		$this->indexBuilt = true;

--- a/src/OEmbed/OEmbedDiscovery.php
+++ b/src/OEmbed/OEmbedDiscovery.php
@@ -65,7 +65,7 @@ final class OEmbedDiscovery {
 			return null;
 		}
 
-		return $this->parseOEmbedLink($html);
+		return $this->parseOEmbedLink($html, $url);
 	}
 
 	/**
@@ -77,6 +77,10 @@ final class OEmbedDiscovery {
 	 * @return \MediaEmbed\OEmbed\OEmbedResponse|null Response or null on failure.
 	 */
 	public function fetch(string $endpointUrl, ?int $maxWidth = null, ?int $maxHeight = null): ?OEmbedResponse {
+		if (!$this->isSafeEndpointUrl($endpointUrl)) {
+			return null;
+		}
+
 		$params = [];
 		if ($maxWidth !== null) {
 			$params['maxwidth'] = $maxWidth;
@@ -109,9 +113,10 @@ final class OEmbedDiscovery {
 	 * Looks for: <link rel="alternate" type="application/json+oembed" href="..." />
 	 *
 	 * @param string $html The HTML to parse.
+	 * @param string $baseUrl Source page URL.
 	 * @return string|null The oEmbed URL or null if not found.
 	 */
-	private function parseOEmbedLink(string $html): ?string {
+	private function parseOEmbedLink(string $html, string $baseUrl): ?string {
 		// Match link tags with oembed type
 		$pattern = '/<link[^>]+type=["\']application\/json\+oembed["\'][^>]*>/i';
 		if (!preg_match($pattern, $html, $match)) {
@@ -131,8 +136,78 @@ final class OEmbedDiscovery {
 
 		$href = $hrefMatch[1];
 
-		// Decode HTML entities
-		return html_entity_decode($href, ENT_QUOTES | ENT_HTML5);
+		$href = html_entity_decode($href, ENT_QUOTES | ENT_HTML5);
+
+		$url = $this->resolveEndpointUrl($href, $baseUrl);
+		if (!$this->isSafeEndpointUrl($url)) {
+			return null;
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Resolve oEmbed href values against the source page URL.
+	 *
+	 * @param string $href Link href from the oEmbed tag.
+	 * @param string $baseUrl Source page URL.
+	 * @return string
+	 */
+	private function resolveEndpointUrl(string $href, string $baseUrl): string {
+		if (parse_url($href, PHP_URL_SCHEME) !== null) {
+			return $href;
+		}
+
+		$base = parse_url($baseUrl);
+		if (empty($base['scheme']) || empty($base['host'])) {
+			return $href;
+		}
+
+		$authority = $base['scheme'] . '://' . $base['host'];
+		if (!empty($base['port'])) {
+			$authority .= ':' . $base['port'];
+		}
+
+		if (str_starts_with($href, '//')) {
+			return $base['scheme'] . ':' . $href;
+		}
+
+		if (str_starts_with($href, '/')) {
+			return $authority . $href;
+		}
+
+		$path = $base['path'] ?? '/';
+		$directory = rtrim(substr($path, 0, (int)strrpos($path, '/') + 1), '/');
+
+		return $authority . $directory . '/' . $href;
+	}
+
+	/**
+	 * Check if an oEmbed endpoint URL is safe to fetch.
+	 *
+	 * @param string $url Endpoint URL.
+	 * @return bool
+	 */
+	private function isSafeEndpointUrl(string $url): bool {
+		$parts = parse_url($url);
+		if (!is_array($parts) || empty($parts['scheme']) || empty($parts['host'])) {
+			return false;
+		}
+
+		if (!in_array(strtolower($parts['scheme']), ['http', 'https'], true)) {
+			return false;
+		}
+
+		$host = strtolower($parts['host']);
+		if ($host === 'localhost' || str_ends_with($host, '.localhost')) {
+			return false;
+		}
+
+		if (filter_var($host, FILTER_VALIDATE_IP)) {
+			return filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) !== false;
+		}
+
+		return true;
 	}
 
 }

--- a/src/Object/MediaObject.php
+++ b/src/Object/MediaObject.php
@@ -85,8 +85,12 @@ class MediaObject implements ObjectInterface {
 		}
 
 		if ($type === 'iframe-player') {
-			$src = $this->_getObjectSrc($type);
-			$this->_stub['iframe-player'] = $src;
+			if (!empty($this->_stub['reverse'])) {
+				$src = $this->_getObjectSrc($type);
+				$this->_stub['iframe-player'] = $src;
+			} else {
+				$src = $this->templateResolver->resolve($this->_stub['iframe-player'], $this->_match);
+			}
 
 			$this->_objectParams['movie'] = $src;
 			$this->_objectAttributes['data'] = $src;

--- a/src/Object/MediaObject.php
+++ b/src/Object/MediaObject.php
@@ -374,12 +374,21 @@ class MediaObject implements ObjectInterface {
 		if ($this->_iframeParams) {
 			$c = '?';
 			if (strpos($source, '?') !== false) {
-				$c = '&amp;';
+				$c = '&';
 			}
-			$source .= $c . http_build_query($this->_iframeParams, '', '&amp;');
+			$source .= $c . http_build_query($this->_iframeParams);
 		}
 
 		return $source;
+	}
+
+	/**
+	 * Get the iframe src URL escaped for HTML attributes.
+	 *
+	 * @return string The escaped src attribute value
+	 */
+	public function getEmbedSrcForHtml(): string {
+		return $this->_esc($this->getEmbedSrc());
 	}
 
 	/**
@@ -468,16 +477,6 @@ class MediaObject implements ObjectInterface {
 	 * @return string
 	 */
 	protected function _buildIframe(): string {
-		$source = $this->templateResolver->resolve($this->_stub['iframe-player'], $this->_match);
-
-		//add custom params
-		if ($this->_iframeParams) {
-			$c = '?';
-			if (strpos($source, '?') !== false) {
-				$c = '&amp;';
-			}
-			$source .= $c . http_build_query($this->_iframeParams, '', '&amp;');
-		}
 		$attributes = '';
 		//add custom attributes
 
@@ -490,7 +489,7 @@ class MediaObject implements ObjectInterface {
 		}
 
 		// Transparent hack (http://groups.google.com/group/autoembed/browse_thread/thread/0ecdd9b898e12183)
-		return sprintf('<iframe src="%s"%s></iframe>', $source, $attributes);
+		return sprintf('<iframe src="%s"%s></iframe>', $this->getEmbedSrcForHtml(), $attributes);
 	}
 
 	/**

--- a/src/Object/MediaObject.php
+++ b/src/Object/MediaObject.php
@@ -2,6 +2,7 @@
 
 namespace MediaEmbed\Object;
 
+use InvalidArgumentException;
 use MediaEmbed\Template\TemplateResolver;
 
 /**
@@ -264,13 +265,26 @@ class MediaObject implements ObjectInterface {
 
 		if (is_array($param)) {
 			foreach ($param as $p => $v) {
+				$this->assertValidAttributeName((string)$p);
 				$this->{$attributes}[$p] = $v;
 			}
 		} else {
+			$this->assertValidAttributeName((string)$param);
 			$this->{$attributes}[$param] = $value;
 		}
 
 		return $this;
+	}
+
+	/**
+	 * @param string $name Attribute name.
+	 * @throws \InvalidArgumentException
+	 * @return void
+	 */
+	protected function assertValidAttributeName(string $name): void {
+		if (!preg_match('/^[^\s"\'=<>\/\x00-\x1F\x7F]+$/', $name) || preg_match('/^on/i', $name)) {
+			throw new InvalidArgumentException(sprintf('Invalid iframe attribute name "%s"', $name));
+		}
 	}
 
 	/**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -20,6 +20,23 @@ class HttpClientTest extends TestCase {
 		$this->assertInstanceOf(StreamHttpClient::class, $client);
 	}
 
+	public function testStreamHttpClientWithCustomMaxBytes(): void {
+		$client = new StreamHttpClient(10, 1024);
+
+		$this->assertInstanceOf(StreamHttpClient::class, $client);
+	}
+
+	public function testGetReturnsNullForUnsafeUrls(): void {
+		$client = new StreamHttpClient(1);
+
+		$this->assertNull($client->get('file:///tmp/test.txt'));
+		$this->assertNull($client->get('javascript:alert(1)'));
+		$this->assertNull($client->get('http://localhost/test'));
+		$this->assertNull($client->get('http://127.0.0.1/test'));
+		$this->assertNull($client->get('http://10.0.0.1/test'));
+		$this->assertNull($client->get('http://169.254.169.254/test'));
+	}
+
 	public function testGetReturnsNullForInvalidUrl(): void {
 		$client = new StreamHttpClient(1);
 

--- a/tests/MediaEmbedTest.php
+++ b/tests/MediaEmbedTest.php
@@ -130,6 +130,44 @@ class MediaEmbedTest extends TestCase {
 		$this->assertNull($result);
 	}
 
+	public function testParseUrlRejectsTextContainingSupportedUrl(): void {
+		$MediaEmbed = new MediaEmbed();
+		$result = $MediaEmbed->parseUrl('Watch https://www.youtube.com/watch?v=yiSjHJnc9CY now');
+
+		$this->assertNull($result);
+	}
+
+	public function testParseUrlRejectsWrapperUrlContainingSupportedUrl(): void {
+		$MediaEmbed = new MediaEmbed();
+		$result = $MediaEmbed->parseUrl('https://example.com/?u=https://www.youtube.com/watch?v=yiSjHJnc9CY');
+
+		$this->assertNull($result);
+	}
+
+	public function testParseUrlRejectsNonHttpUrl(): void {
+		$MediaEmbed = new MediaEmbed();
+		$result = $MediaEmbed->parseUrl('javascript:https://www.youtube.com/watch?v=yiSjHJnc9CY');
+
+		$this->assertNull($result);
+	}
+
+	public function testParseUrlSupportsUnindexedCustomProviderPattern(): void {
+		$MediaEmbed = new MediaEmbed();
+		$MediaEmbed->addProvider([
+			'name' => 'UnindexedProvider',
+			'website' => 'https://unindexed.example.com',
+			'url-match' => 'https?://[^/]+/unindexed/([0-9]+)',
+			'embed-src' => '//unindexed.example.com/embed/$2',
+			'embed-width' => 640,
+			'embed-height' => 360,
+			'iframe-player' => '//unindexed.example.com/embed/$2',
+		]);
+
+		$Object = $MediaEmbed->parseUrl('https://video.example.org/unindexed/12345');
+		$this->assertInstanceOf(MediaObject::class, $Object);
+		$this->assertSame('12345', $Object->id());
+	}
+
 	/**
 	 * @dataProvider getUrls
 	 * @param string $url

--- a/tests/MediaEmbedTest.php
+++ b/tests/MediaEmbedTest.php
@@ -2,6 +2,7 @@
 
 namespace MediaEmbed\Test;
 
+use InvalidArgumentException;
 use MediaEmbed\MediaEmbed;
 use MediaEmbed\Object\MediaObject;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -275,6 +276,44 @@ class MediaEmbedTest extends TestCase {
 		$this->assertStringNotContainsString('bar="quoted"', $code);
 		$this->assertSame('//unsafe.example.com/embed/12345?foo=1&bar="quoted"&wmode=transparent', $Object->getEmbedSrc());
 		$this->assertSame('//unsafe.example.com/embed/12345?foo=1&amp;bar=&quot;quoted&quot;&amp;wmode=transparent', $Object->getEmbedSrcForHtml());
+	}
+
+	public function testSetAttributeRejectsInvalidAttributeName(): void {
+		$MediaEmbed = new MediaEmbed();
+		$Object = $MediaEmbed->parseUrl('https://www.youtube.com/watch?v=11111111111');
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid iframe attribute name "x onload"');
+
+		$Object->setAttribute('x onload', 'alert(1)');
+	}
+
+	public function testSetAttributeRejectsEventHandlerAttributeName(): void {
+		$MediaEmbed = new MediaEmbed();
+		$Object = $MediaEmbed->parseUrl('https://www.youtube.com/watch?v=11111111111');
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid iframe attribute name "onload"');
+
+		$Object->setAttribute('onload', 'alert(1)');
+	}
+
+	public function testSetAttributeAllowsDataAndAriaAttributes(): void {
+		$MediaEmbed = new MediaEmbed();
+		$Object = $MediaEmbed->parseUrl('https://www.youtube.com/watch?v=11111111111');
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		$Object->setAttribute([
+			'data-controller' => 'media',
+			'aria-label' => 'Video',
+		]);
+
+		$code = $Object->getEmbedCode();
+
+		$this->assertStringContainsString(' data-controller="media"', $code);
+		$this->assertStringContainsString(' aria-label="Video"', $code);
 	}
 
 	/**

--- a/tests/MediaEmbedTest.php
+++ b/tests/MediaEmbedTest.php
@@ -160,6 +160,37 @@ class MediaEmbedTest extends TestCase {
 	}
 
 	/**
+	 * @dataProvider getEmbedSrcUrls
+	 * @param string $url
+	 * @param string $expected
+	 * @return void
+	 */
+	#[DataProvider('getEmbedSrcUrls')]
+	public function testGetEmbedSrc(string $url, string $expected): void {
+		$MediaEmbed = new MediaEmbed();
+		$Object = $MediaEmbed->parseUrl($url);
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		$this->assertSame($expected, $Object->getEmbedSrc());
+	}
+
+	/**
+	 * Data provider for expected embed src URLs.
+	 *
+	 * @return array
+	 */
+	public static function getEmbedSrcUrls(): array {
+		return [
+			['https://www.mixcloud.com/spartacus/party-time/', '//www.mixcloud.com/widget/iframe/?feed=https%3A%2F%2Fwww.mixcloud.com%2Fspartacus%2Fparty-time%2F&wmode=transparent'],
+			['https://open.spotify.com/track/4iV5W9uYEdYUVa79Axb7Rh', 'https://open.spotify.com/embed/track/4iV5W9uYEdYUVa79Axb7Rh?wmode=transparent'],
+			['https://artist.bandcamp.com/track/song-title', 'https://bandcamp.com/EmbeddedPlayer/track=artist/size=large/bgcol=ffffff/linkcol=0687f5/tracklist=false/transparent=true/?wmode=transparent'],
+			['https://peertube.example.org/w/abc123XYZ', 'https://peertube.example.org/videos/embed/abc123XYZ?wmode=transparent'],
+			['https://www.metatube.com/en/videos/245145/J-Alvarez-Tu-Cuerpo-Pide-Fiesta/', 'https://www.metatube.com/en/videos/245145/J-Alvarez-Tu-Cuerpo-Pide-Fiesta/embed/?wmode=transparent'],
+			['https://lds.cdn.vooplayer.com/publish/MTEwNTMw', 'https://lds.cdn.vooplayer.com/publish/MTEwNTMw?fallback=true&wmode=transparent'],
+		];
+	}
+
+	/**
 	 * Test parseId()
 	 *
 	 * @return void
@@ -221,6 +252,29 @@ class MediaEmbedTest extends TestCase {
 
 		$code = $Object->getEmbedCode();
 		$this->assertStringNotContainsString('<iframe', $code);
+	}
+
+	public function testEmbedCodeEscapesIframeSource(): void {
+		$MediaEmbed = new MediaEmbed();
+		$MediaEmbed->addProvider([
+			'name' => 'UnsafeProvider',
+			'website' => 'https://unsafe.example.com',
+			'url-match' => 'https://unsafe\\.example\\.com/video/([0-9]+)',
+			'embed-src' => '//unsafe.example.com/embed/$2',
+			'embed-width' => 640,
+			'embed-height' => 360,
+			'iframe-player' => '//unsafe.example.com/embed/$2?foo=1&bar="quoted"',
+		]);
+
+		$Object = $MediaEmbed->parseUrl('https://unsafe.example.com/video/12345');
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		$code = $Object->getEmbedCode();
+
+		$this->assertStringContainsString('src="//unsafe.example.com/embed/12345?foo=1&amp;bar=&quot;quoted&quot;&amp;wmode=transparent"', $code);
+		$this->assertStringNotContainsString('bar="quoted"', $code);
+		$this->assertSame('//unsafe.example.com/embed/12345?foo=1&bar="quoted"&wmode=transparent', $Object->getEmbedSrc());
+		$this->assertSame('//unsafe.example.com/embed/12345?foo=1&amp;bar=&quot;quoted&quot;&amp;wmode=transparent', $Object->getEmbedSrcForHtml());
 	}
 
 	/**

--- a/tests/OEmbed/OEmbedTest.php
+++ b/tests/OEmbed/OEmbedTest.php
@@ -93,6 +93,28 @@ class OEmbedTest extends TestCase {
 		$this->assertNull($endpoint);
 	}
 
+	public function testOEmbedDiscoveryRejectsUnsafeEndpointScheme(): void {
+		$mockClient = $this->createStub(HttpClientInterface::class);
+		$mockClient->method('get')
+			->willReturn('<html><head><link rel="alternate" type="application/json+oembed" href="javascript:alert(1)" /></head></html>');
+
+		$discovery = new OEmbedDiscovery($mockClient);
+		$endpoint = $discovery->discoverEndpoint('https://example.com/page');
+
+		$this->assertNull($endpoint);
+	}
+
+	public function testOEmbedDiscoveryRejectsProtocolRelativeLocalhostEndpoint(): void {
+		$mockClient = $this->createStub(HttpClientInterface::class);
+		$mockClient->method('get')
+			->willReturn('<html><head><link rel="alternate" type="application/json+oembed" href="//localhost/oembed" /></head></html>');
+
+		$discovery = new OEmbedDiscovery($mockClient);
+		$endpoint = $discovery->discoverEndpoint('https://example.com/page');
+
+		$this->assertNull($endpoint);
+	}
+
 	public function testOEmbedDiscoveryFetch(): void {
 		$mockClient = $this->createMock(HttpClientInterface::class);
 		$mockClient->method('get')
@@ -109,6 +131,18 @@ class OEmbedTest extends TestCase {
 		$this->assertNotNull($response);
 		$this->assertSame('video', $response->type);
 		$this->assertSame('Mock Video', $response->title);
+	}
+
+	public function testOEmbedDiscoveryFetchRejectsUnsafeEndpoint(): void {
+		$mockClient = $this->createMock(HttpClientInterface::class);
+		$mockClient->expects($this->never())
+			->method('get');
+
+		$discovery = new OEmbedDiscovery($mockClient);
+
+		$this->assertNull($discovery->fetch('file:///tmp/oembed.json'));
+		$this->assertNull($discovery->fetch('http://127.0.0.1/oembed'));
+		$this->assertNull($discovery->fetch('http://10.0.0.1/oembed'));
 	}
 
 	public function testOEmbedDiscoveryFetchWithDimensions(): void {


### PR DESCRIPTION
This backports the BC-compatible hardening fixes requested for the current stable branch.

Included:
- Escape iframe `src` values while keeping raw `getEmbedSrc()` available separately from `getEmbedSrcForHtml()`.
- Reject invalid iframe/object attribute names, including `on*` event handler attributes.
- Reject unsafe oEmbed endpoint URLs and resolve relative oEmbed endpoints before fetching.
- Harden the default stream HTTP client against unsafe/private targets.
- Tighten URL matching so wrapper URLs containing a provider URL in their path/query are not parsed as that provider.

Skipped as requested:
- README badge URL changes.

Local checks:
- `composer cs-fix`
- `composer cs-check`
- `composer test` (green with 3 existing PHPUnit notices)
- `composer stan`