### PR TITLE
Polish next release hardening and examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,5 +106,7 @@ jobs:
       - name: Run link checker
         run: |
           sudo npm install -g markdown-link-check
-          markdown-link-check README.md
+          markdown-link-check README.md -p -c tests/link-check-config.json
+          markdown-link-check docs/README.md -p -c tests/link-check-config.json
           markdown-link-check docs/supported.md -p -c tests/link-check-config.json
+          markdown-link-check UPGRADE.md -p -c tests/link-check-config.json

--- a/docs/README.md
+++ b/docs/README.md
@@ -444,7 +444,7 @@ use Psr\SimpleCache\CacheInterface;
 $MediaEmbed = new MediaEmbed(cache: $yourPsr16Cache, cacheTtl: 3600);
 ```
 
-The cache stores the generated provider domain index under an internal key. It is invalidated automatically when providers change. The `cacheTtl` argument controls how long persistent caches may retain the index.
+The cache stores the generated provider domain index under an internal key. It is invalidated automatically when providers change. The `cacheTtl` argument controls how long persistent caches may retain the index. The built-in `ArrayCache` honors TTL values and can store `null` values.
 
 ### oEmbed Discovery
 

--- a/examples/bbcode.php
+++ b/examples/bbcode.php
@@ -1,14 +1,20 @@
 <?php
-include dirname(dirname(__FILE__)) . '/vendor/autoload.php';
-include dirname(__FILE__) . '/lib/functions.php';
-include dirname(__FILE__) . '/lib/MediaEmbedBehavior.php';
 
-$video = 'http://www.youtube.com/watch?v=yiSjHJnc9CY';
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+require __DIR__ . '/lib/functions.php';
+require __DIR__ . '/lib/MediaEmbedBehavior.php';
+
+$video = 'https://www.youtube.com/watch?v=yiSjHJnc9CY';
 $string = 'Cool video: [video]' . $video . '[/video] Like it - now!';
+$behavior = new MediaEmbedBehavior();
+$input = $behavior->simulateSave($string);
+$output = $behavior->prepareForOutput($input);
 ?>
 <style>
 table td {
-	 vertical-align: top;
+	vertical-align: top;
 }
 td.types {
 	width: 300px;
@@ -16,34 +22,26 @@ td.types {
 </style>
 
 <h1>BBCode Video Examples</h1>
-<p>You can use Markdown or BBCode snippets to transform your text into a embed media snippet.</p>
+<p>You can use Markdown or BBCode snippets to transform text into an embedded media snippet.</p>
 
 <table><tr><td class="types">
 <h2>BBCode</h2>
-<code><pre><?php echo $string;?></pre></code>
+<code><pre><?php echo h($string); ?></pre></code>
 
 That is the user input from a textarea, for example.
 
 <h2>Upon save it will be processed</h2>
-<?php
-	$Behavior = new \MediaEmbedBehavior();
-	$input = $Behavior->simulateSave($string);
-?>
-<code><pre><?php echo $input; ?></pre></code>
+<code><pre><?php echo h($input); ?></pre></code>
 
-<p>You may also validate it and act accordingly (prevent save or remove the video and alert the user).</p>
+<p>You may also validate it and act accordingly.</p>
 
 <h2>Upon display we transform it again</h2>
-The final HTML output:
-<?php
-	$output = $Behavior->prepareForOutput($input);
-?>
-<code><pre><?php echo $output; ?></pre></code>
+<code><pre><?php echo h($output); ?></pre></code>
 
+<h2>Rendered output</h2>
+<?php echo $output; ?>
 </td></tr></table>
 
-<p>That's it! :)</p>
-
 <p>
-If there are outdated (not working) example URLs or missing types, let me know or provide a PR in <a href="https://github.com/dereuromark/MediaEmbed" target="_blank">GitHub</a> to fix this.
+If there are outdated example URLs or missing types, let us know or provide a PR in <a href="https://github.com/dereuromark/media-embed" target="_blank" rel="noopener">GitHub</a>.
 </p>

--- a/examples/data/videos.csv
+++ b/examples/data/videos.csv
@@ -1,15 +1,25 @@
 host,url,attributes,params
-YouTube, "http://www.youtube.com/watch?v=yiSjHJnc9CY"
-YouTube-Embed, "http://www.youtube.com/embed/yiSjHJnc9CY?rel=0"
-YouTube-Attributes, "http://www.youtube.com/watch?v=yiSjHJnc9CY", "{""class"":""video"",""id"":""video_test"",""data-something"":""test""}", "{""autoplay"":1,""loop"":1,""modestbranding"":1}"
-Dailymotion, "http://www.dailymotion.com/video/xgv8nw_david-guetta-who-s-that-chick_music"
-Dailymotion-Short, "http://dai.ly/x2bqyl6"
-Vimeo, "http://vimeo.com/channels/staffpicks/99585787"
-MyVideo, "http://www.myvideo.de/watch/7645001/Lena_Nach_Poolszene_bald_nackt_im_Playboy"
-ClipFish, "http://www.clipfish.de/musikvideos/video/3486922/nicole-scherzinger-poison"
-videojug, "http://www.videojug.com/film/summer-party-look-with-daniel-sandler"
-Ustream, "http://www.ustream.tv/channel/america2oficial"
-Metatube, "http://www.metatube.com/en/videos/245145/J-Alvarez-Tu-Cuerpo-Pide-Fiesta/"
-Screencast, "http://www.screencast.com/t/Hh4ulI0M"
-Aparat, "http://www.aparat.com/v/sSLMC"
-Blip, "http://blip.tv/stylestar/shine-6866879"
+YouTube,https://www.youtube.com/watch?v=yiSjHJnc9CY
+YouTube Embed,https://www.youtube.com/embed/yWm4YwqO93I?rel=0
+YouTube Attributes,https://www.youtube.com/watch?v=yiSjHJnc9CY,"{""class"":""video"",""id"":""video_test"",""data-something"":""test""}","{""autoplay"":1,""loop"":1,""modestbranding"":1}"
+Dailymotion,https://www.dailymotion.com/video/x2bqyl6_l-entourloop-ft-ruffian-rugged-madder-than-dat_music
+Dailymotion Short,https://dai.ly/x2bqyl6
+Vimeo,https://vimeo.com/channels/staffpicks/99585787
+Facebook,https://www.facebook.com/mega90er/videos/1309058692443747/
+Instagram,https://www.instagram.com/p/ABC123xyz/
+TikTok,https://www.tiktok.com/@username/video/7123456789012345678
+Twitch Video,https://www.twitch.tv/videos/293684811
+Twitch Clip,https://clips.twitch.tv/WonderfulPiliableSquirrelBleedPurple
+Spotify,https://open.spotify.com/track/4iV5W9uYEdYUVa79Axb7Rh
+SoundCloud,https://soundcloud.com/kalax/kalax-take-me-back-feat-world-wild-1
+Mixcloud,https://www.mixcloud.com/spartacus/party-time/
+Reddit,https://www.reddit.com/r/videos/comments/abc123/some_title/
+Streamable,https://streamable.com/abc123
+Bandcamp,https://artist.bandcamp.com/track/song-title
+PeerTube,https://peertube.example.org/w/abc123XYZ
+Rumble,https://rumble.com/v1abc12-example-video.html
+Odysee,https://odysee.com/$/embed/video-title/abc123def
+Kick,https://kick.com/username/clips/clip_abc123
+Aparat,https://www.aparat.com/v/sSLMC
+Matterport,https://my.matterport.com/show/?m=Zh14WDtkjdC&lp=1
+Metatube,https://www.metatube.com/en/videos/245145/J-Alvarez-Tu-Cuerpo-Pide-Fiesta/

--- a/examples/index.php
+++ b/examples/index.php
@@ -1,13 +1,21 @@
 <?php
-include dirname(dirname(__FILE__)) . '/vendor/autoload.php';
-include dirname(__FILE__) . '/lib/functions.php';
 
-$file = dirname(__FILE__) . '/data/videos.csv';
-$videos = getVideos($file);
+declare(strict_types=1);
+
+use MediaEmbed\MediaEmbed;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+require __DIR__ . '/lib/functions.php';
+
+$videos = getVideos(__DIR__ . '/data/videos.csv');
+$mediaEmbed = new MediaEmbed();
+$hosts = $mediaEmbed->getHosts();
+ksort($hosts);
+$selectedType = is_string($_GET['type'] ?? null) ? $_GET['type'] : null;
 ?>
 <style>
 table td {
-	 vertical-align: top;
+	vertical-align: top;
 }
 td.types {
 	width: 300px;
@@ -27,102 +35,83 @@ ul.no-examples li {
 <table><tr><td class="types">
 <h2>Select Type</h2>
 <ul>
-<?php
-$MediaEmbed = new \MediaEmbed\MediaEmbed();
-$hosts = $MediaEmbed->getHosts();
-ksort($hosts);
-
-foreach ($videos as $name => $parts) {
-	$url = $parts[0];
-	$attributes = $parts[1];
-	$params = $parts[2];
-?>
-	<li><a href="index.php?type=<?php echo $name; ?>"><?php echo $name; ?></a></li>
-<?php
-}
-?>
+<?php foreach ($videos as $name => $parts): ?>
+	<li><a href="index.php?type=<?php echo h($name); ?>"><?php echo h($name); ?></a></li>
+<?php endforeach; ?>
 </ul>
 
 <ul class="no-examples">
-<?php
-foreach ($hosts as $slug => $host) {
-	if ($host['name'] === '$2' || array_key_exists($host['name'], $videos)) {
-		continue;
-	}
-?>
-	<li><?php echo $host['name']; ?></li>
-<?php
-}
-?>
+<?php foreach ($hosts as $host): ?>
+	<?php if ($host['name'] === '$2' || array_key_exists($host['name'], $videos)): ?>
+		<?php continue; ?>
+	<?php endif; ?>
+	<li><?php echo h((string)$host['name']); ?></li>
+<?php endforeach; ?>
 </ul>
 
 Currently supported services: <?php echo count($hosts); ?><br />
 Examples available for <?php echo count($videos); ?> services.
 </td><td>
-<?php
-	if (!empty($_GET['type']) && isset($videos[$_GET['type']])) {
-		$videoUrl = $videos[$_GET['type']][0];
-		$videoAttributes = $videos[$_GET['type']][1];
-		$videoParams = $videos[$_GET['type']][2];
+<?php if ($selectedType !== null && isset($videos[$selectedType])): ?>
+	<?php
+		$videoUrl = $videos[$selectedType][0];
+		$videoAttributes = $videos[$selectedType][1];
+		$videoParams = $videos[$selectedType][2];
+		$mediaObject = $mediaEmbed->parseUrl($videoUrl);
+		if ($mediaObject === null) {
+			throw new RuntimeException('An error occurred with this type.');
+		}
+	?>
 
-		echo '<h2>"' . $_GET['type'] . '"</h2>';
-		echo '<p>Video URL: ' . $videoUrl . '</p>';
+	<h2><?php echo h($selectedType); ?></h2>
+	<p>Video URL: <?php echo h($videoUrl); ?></p>
+	<?php if ($videoAttributes): ?>
+		<p>Video Attributes: <pre><?php echo h(print_r($videoAttributes, true)); ?></pre></p>
+	<?php endif; ?>
+	<?php if ($videoParams): ?>
+		<p>Video Params: <pre><?php echo h(print_r($videoParams, true)); ?></pre></p>
+	<?php endif; ?>
+
+	<table><tr><td>
+	<h3>Parsing Result</h3>
+	Video ID: <?php echo h($mediaObject->id()); ?>
+
+	<h3>Embedded Media</h3>
+	<?php
 		if ($videoAttributes) {
-			echo '<p>Video Attributes: <pre>' . print_r($videoAttributes, 1) . '</pre></p>';
+			$mediaObject->setAttribute($videoAttributes);
 		}
 		if ($videoParams) {
-			echo '<p>Video Params: <pre>' . print_r($videoParams, 1) . '</pre></p>';
+			$mediaObject->setParam($videoParams);
 		}
-
-		$Object = $MediaEmbed->parseUrl($videoUrl);
-		if (!$Object) {
-			throw new Exception('An error occured with this type');
-		}
-
-		echo '<table><tr><td>';
-
-		echo '<h3>Parsing Result</h3>';
-		echo 'Video ID: ' . $Object->id();
-
-		echo '<h3>Embedded Media</h3>';
-		//adding attributes
-		if ($videoAttributes) {
-			$Object->setAttribute($videoAttributes);
-		}
-		//adding params
-		if ($videoParams) {
-			$Object->setParam($videoParams);
-		}
-		$embed = $Object->getEmbedCode();
-  	// or
-		//$embed = (string)$result;
+		$embed = $mediaObject->getEmbedCode();
 		echo $embed;
+	?>
 
-		echo '<div><h3>Embed code:</h3><textarea>' . htmlspecialchars($embed) . '</textarea></div>';
-
-		echo '</td><td>';
-		$id = $Object->id();
-		$slug = $Object->slug();
-		//remove some params here
-		$Object->setParam('autoplay', 0);
-		$ObjectFromReverseLookup = $MediaEmbed->parseId($id, $slug);
-		echo '<h3>Reverse lookup by video id and host slug</h3>';
-		echo 'Result: ' . ($ObjectFromReverseLookup ? 'OK' : 'ERROR');
-
-		if ($ObjectFromReverseLookup) {
-			echo '<h3>Embedded Media</h3>';
-			$embed = $Object->getEmbedCode();
-
-			echo $embed;
-
-			echo '<div><h3>Embed code:</h3><textarea>' . htmlspecialchars($embed) . '</textarea></div>';
+	<div><h3>Embed code:</h3><textarea><?php echo h($embed); ?></textarea></div>
+	</td><td>
+	<?php
+		$id = $mediaObject->id();
+		$slug = $mediaObject->slug();
+		$reverseLookupObject = $mediaEmbed->parseId($id, $slug);
+		$reverseEmbed = null;
+		if ($reverseLookupObject !== null && !str_contains($reverseLookupObject->getEmbedSrc(), '$')) {
+			$reverseEmbed = $reverseLookupObject->getEmbedCode();
 		}
+	?>
 
-		echo '</td></tr></table>';
-	}
-?>
+	<h3>Reverse lookup by video id and host slug</h3>
+	Result: <?php echo $reverseEmbed !== null ? 'OK' : 'Not available for this provider'; ?>
+
+	<?php if ($reverseEmbed !== null): ?>
+		<h3>Embedded Media</h3>
+		<?php echo $reverseEmbed; ?>
+		<div><h3>Embed code:</h3><textarea><?php echo h($reverseEmbed); ?></textarea></div>
+	<?php endif; ?>
+	</td></tr></table>
+<?php endif; ?>
 </td></tr></table>
 
 <p>
-If there are outdated (not working) example URLs or missing types, let me know or provide a PR in <a href="https://github.com/dereuromark/MediaEmbed" target="_blank">GitHub</a> to fix this.
+If there are outdated example URLs or missing types, let us know or provide a PR in <a href="https://github.com/dereuromark/media-embed" target="_blank" rel="noopener">GitHub</a>.
 </p>

--- a/examples/lib/MediaEmbedBehavior.php
+++ b/examples/lib/MediaEmbedBehavior.php
@@ -1,71 +1,62 @@
 <?php
 
+declare(strict_types=1);
+
 use MediaEmbed\MediaEmbed;
 
 class MediaEmbedBehavior {
 
+	private ?MediaEmbed $mediaEmbed = null;
+
 	/**
-	 * We translate all BBCodes into HTML now.
-	 *
-	 * @param string $string
-	 * @return string
+	 * Translate stored BBCodes into HTML.
 	 */
-	public function prepareForOutput($string) {
-		return preg_replace_callback('/\[video=?(.*?)\](.*?)\[\/video\]/is', [$this, '_finalizeVideo'], $string);
+	public function prepareForOutput(string $string): string {
+		return (string)preg_replace_callback('/\[video=?(.*?)\](.*?)\[\/video\]/is', [$this, 'finalizeVideo'], $string);
 	}
 
 	/**
-	 * @param array $params
-	 * @return string
+	 * Simulate a save operation and return normalized video BBCodes.
 	 */
-	protected function _finalizeVideo($params) {
-		if (!isset($this->MediaEmbed)) {
-			$this->MediaEmbed = new MediaEmbed();
-		}
-		$host = $params[1];
-		$id = $params[2];
-		if (!($MediaObject = $this->MediaEmbed->parseId($id, $host))) {
+	public function simulateSave(string $string): string {
+		return (string)preg_replace_callback('/\[video=?(.*?)\](.*?)\[\/video\]/is', [$this, 'processVideo'], $string);
+	}
+
+	/**
+	 * @param array<int, string> $params
+	 */
+	protected function finalizeVideo(array $params): string {
+		$mediaObject = $this->mediaEmbed()->parseId($params[2], $params[1]);
+		if ($mediaObject === null) {
 			return $params[0];
 		}
 
-		return $MediaObject->getEmbedCode();
+		return $mediaObject->getEmbedCode();
 	}
 
 	/**
-	 * We simulate a save operation and simply return the modified string again.
-	 *
-	 * @param string $string
-	 * @return string
+	 * @param array<int, string> $params
 	 */
-	public function simulateSave($string) {
-		return preg_replace_callback('/\[video=?(.*?)\](.*?)\[\/video\]/is', [$this, '_processVideo'], $string);
-	}
-
-	/**
-	 * @param array $params
-	 * @return string
-	 */
-	protected function _processVideo($params) {
-		if (!isset($this->MediaEmbed)) {
-			$this->MediaEmbed = new MediaEmbed();
-		}
+	protected function processVideo(array $params): string {
 		$url = $params[2];
-		if (strpos($url, 'www.') === 0) {
-			$url = 'http://' . $url;
+		if (str_starts_with($url, 'www.')) {
+			$url = 'https://' . $url;
 		}
-		if (!($MediaObject = $this->MediaEmbed->parseUrl($url))) {
+
+		$mediaObject = $this->mediaEmbed()->parseUrl($url);
+		if ($mediaObject === null) {
 			return $params[0];
 		}
-		$slug = $MediaObject->slug();
-		if (!$slug) {
-			$slug = $params[1];
+
+		return '[video=' . $mediaObject->slug() . ']' . $mediaObject->id() . '[/video]';
+	}
+
+	protected function mediaEmbed(): MediaEmbed {
+		if ($this->mediaEmbed === null) {
+			$this->mediaEmbed = new MediaEmbed();
 		}
-		if ($slug) {
-			$slug = '=' . $slug;
-		}
-		$id = $MediaObject->id();
-		$result = '[video' . $slug . ']' . $id . '[/video]';
-		return $result;
+
+		return $this->mediaEmbed;
 	}
 
 }

--- a/examples/lib/functions.php
+++ b/examples/lib/functions.php
@@ -1,19 +1,51 @@
 <?php
 
-function getVideos($file) {
-	$videos = [];
+declare(strict_types=1);
 
-	if (($handle = fopen($file, 'r')) !== false) {
-		$count = 0;
-		while (($data = fgetcsv($handle, 0)) !== false) {
-			$count++;
-			// Empty rows and header (host, url) should be skipped
-			if ($count === 1 || empty($data[0]) || empty($data[1])) {
-				continue;
-			}
-			$count++;
-			$videos[$data[0]] = [$data[1], json_decode($data[2], true), json_decode($data[3], true)];
-		}
+/**
+ * @return array<string, array{0: string, 1: array<string, mixed>, 2: array<string, mixed>}>
+ */
+function getVideos(string $file): array {
+	$videos = [];
+	$handle = fopen($file, 'r');
+	if ($handle === false) {
+		return $videos;
 	}
+
+	$row = 0;
+	while (($data = fgetcsv($handle)) !== false) {
+		$row++;
+		if ($row === 1 || empty($data[0]) || empty($data[1])) {
+			continue;
+		}
+
+		$videos[$data[0]] = [
+			$data[1],
+			decodeJsonColumn($data[2] ?? null),
+			decodeJsonColumn($data[3] ?? null),
+		];
+	}
+	fclose($handle);
+
 	return $videos;
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function decodeJsonColumn(?string $value): array {
+	if ($value === null || $value === '') {
+		return [];
+	}
+
+	$decoded = json_decode($value, true);
+	if (!is_array($decoded)) {
+		return [];
+	}
+
+	return $decoded;
+}
+
+function h(string $value): string {
+	return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 }

--- a/src/Cache/ArrayCache.php
+++ b/src/Cache/ArrayCache.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MediaEmbed\Cache;
 
 use DateInterval;
+use DateTimeImmutable;
 
 /**
  * Simple in-memory array cache.
@@ -15,7 +16,7 @@ use DateInterval;
 final class ArrayCache implements CacheInterface {
 
 	/**
-	 * @var array<string, mixed>
+	 * @var array<string, array{value: mixed, expires: float|null}>
 	 */
 	private array $cache = [];
 
@@ -23,14 +24,21 @@ final class ArrayCache implements CacheInterface {
 	 * @inheritDoc
 	 */
 	public function get(string $key, mixed $default = null): mixed {
-		return $this->cache[$key] ?? $default;
+		if (!$this->has($key)) {
+			return $default;
+		}
+
+		return $this->cache[$key]['value'];
 	}
 
 	/**
 	 * @inheritDoc
 	 */
 	public function set(string $key, mixed $value, DateInterval|int|null $ttl = null): bool {
-		$this->cache[$key] = $value;
+		$this->cache[$key] = [
+			'value' => $value,
+			'expires' => $this->expiresAt($ttl),
+		];
 
 		return true;
 	}
@@ -48,7 +56,18 @@ final class ArrayCache implements CacheInterface {
 	 * @inheritDoc
 	 */
 	public function has(string $key): bool {
-		return isset($this->cache[$key]);
+		if (!array_key_exists($key, $this->cache)) {
+			return false;
+		}
+
+		$expires = $this->cache[$key]['expires'];
+		if ($expires !== null && $expires <= microtime(true)) {
+			unset($this->cache[$key]);
+
+			return false;
+		}
+
+		return true;
 	}
 
 	/**
@@ -100,6 +119,22 @@ final class ArrayCache implements CacheInterface {
 		}
 
 		return true;
+	}
+
+	/**
+	 * @param \DateInterval|int|null $ttl
+	 * @return float|null
+	 */
+	private function expiresAt(DateInterval|int|null $ttl): ?float {
+		if ($ttl === null) {
+			return null;
+		}
+
+		if ($ttl instanceof DateInterval) {
+			return (float)(new DateTimeImmutable())->add($ttl)->format('U.u');
+		}
+
+		return microtime(true) + $ttl;
 	}
 
 }

--- a/src/Http/StreamHttpClient.php
+++ b/src/Http/StreamHttpClient.php
@@ -63,25 +63,7 @@ class StreamHttpClient implements HttpClientInterface {
 	 * @return bool
 	 */
 	protected function isSafeUrl(string $url): bool {
-		$parts = parse_url($url);
-		if (!is_array($parts) || empty($parts['scheme']) || empty($parts['host'])) {
-			return false;
-		}
-
-		if (!in_array(strtolower($parts['scheme']), ['http', 'https'], true)) {
-			return false;
-		}
-
-		$host = strtolower($parts['host']);
-		if ($host === 'localhost' || str_ends_with($host, '.localhost')) {
-			return false;
-		}
-
-		if (filter_var($host, FILTER_VALIDATE_IP)) {
-			return filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) !== false;
-		}
-
-		return true;
+		return UrlSafety::isPublicHttpUrl($url);
 	}
 
 }

--- a/src/Http/UrlSafety.php
+++ b/src/Http/UrlSafety.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MediaEmbed\Http;
+
+/**
+ * Validates URLs before network fetches.
+ *
+ * @internal
+ */
+final class UrlSafety {
+
+	/**
+	 * @param string $url URL to validate.
+	 * @return bool
+	 */
+	public static function isPublicHttpUrl(string $url): bool {
+		$parts = parse_url($url);
+		if (!is_array($parts) || empty($parts['scheme']) || empty($parts['host'])) {
+			return false;
+		}
+
+		if (!in_array(strtolower($parts['scheme']), ['http', 'https'], true)) {
+			return false;
+		}
+
+		return self::isPublicHost($parts['host']);
+	}
+
+	/**
+	 * @param string $host URL host.
+	 * @return bool
+	 */
+	private static function isPublicHost(string $host): bool {
+		$host = strtolower(trim($host, '[]'));
+		if ($host === '' || $host === 'localhost' || str_ends_with($host, '.localhost')) {
+			return false;
+		}
+
+		if (filter_var($host, FILTER_VALIDATE_IP)) {
+			return filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) !== false;
+		}
+
+		if (preg_match('/^(?:0x[0-9a-f]+|[0-9.]+)$/i', $host)) {
+			return false;
+		}
+
+		return true;
+	}
+
+}

--- a/src/MediaEmbed.php
+++ b/src/MediaEmbed.php
@@ -317,9 +317,13 @@ class MediaEmbed {
 			$this->providers = [];
 		}
 		foreach ($stubs as $stub) {
-			$slug = !empty($stub['slug']) && is_string($stub['slug']) ? $stub['slug'] : $this->slug($stub['name']);
-			$stub['slug'] = $slug;
-			$this->providers[$slug] = $stub;
+			$config = ProviderConfig::fromArray($stub);
+			$slug = $config->slug ?? $this->slug($config->name);
+			$array = $config->toArray();
+			if (!isset($array['slug'])) {
+				$array['slug'] = $slug;
+			}
+			$this->providers[$slug] = $array;
 		}
 
 		$this->urlMatcher = null; // Reset matcher when hosts change

--- a/src/OEmbed/OEmbedDiscovery.php
+++ b/src/OEmbed/OEmbedDiscovery.php
@@ -6,6 +6,7 @@ namespace MediaEmbed\OEmbed;
 
 use MediaEmbed\Http\HttpClientInterface;
 use MediaEmbed\Http\StreamHttpClient;
+use MediaEmbed\Http\UrlSafety;
 
 /**
  * Discovers and fetches oEmbed data from URLs.
@@ -91,7 +92,7 @@ final class OEmbedDiscovery {
 
 		if ($params) {
 			$separator = str_contains($endpointUrl, '?') ? '&' : '?';
-			$endpointUrl .= $separator . http_build_query($params);
+			$endpointUrl .= $separator . http_build_query($params, '', '&');
 		}
 
 		$json = $this->httpClient->get($endpointUrl);
@@ -210,25 +211,7 @@ final class OEmbedDiscovery {
 	 * @return bool
 	 */
 	private function isSafeEndpointUrl(string $url): bool {
-		$parts = parse_url($url);
-		if (!is_array($parts) || empty($parts['scheme']) || empty($parts['host'])) {
-			return false;
-		}
-
-		if (!in_array(strtolower($parts['scheme']), ['http', 'https'], true)) {
-			return false;
-		}
-
-		$host = strtolower($parts['host']);
-		if ($host === 'localhost' || str_ends_with($host, '.localhost')) {
-			return false;
-		}
-
-		if (filter_var($host, FILTER_VALIDATE_IP)) {
-			return filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) !== false;
-		}
-
-		return true;
+		return UrlSafety::isPublicHttpUrl($url);
 	}
 
 }

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -33,6 +33,33 @@ class CacheTest extends TestCase {
 		$this->assertSame(['foo' => 'bar'], $cache->get('test_key'));
 	}
 
+	public function testArrayCacheStoresNullValues(): void {
+		$cache = new ArrayCache();
+
+		$cache->set('null_key', null);
+
+		$this->assertTrue($cache->has('null_key'));
+		$this->assertNull($cache->get('null_key', 'default'));
+	}
+
+	public function testArrayCacheExpiresValues(): void {
+		$cache = new ArrayCache();
+
+		$cache->set('expired_key', 'value', 0);
+
+		$this->assertFalse($cache->has('expired_key'));
+		$this->assertSame('default', $cache->get('expired_key', 'default'));
+	}
+
+	public function testArrayCacheDateIntervalTtl(): void {
+		$cache = new ArrayCache();
+
+		$cache->set('interval_key', 'value', new DateInterval('PT1S'));
+
+		$this->assertTrue($cache->has('interval_key'));
+		$this->assertSame('value', $cache->get('interval_key'));
+	}
+
 	public function testArrayCacheDelete(): void {
 		$cache = new ArrayCache();
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -35,6 +35,11 @@ class HttpClientTest extends TestCase {
 		$this->assertNull($client->get('http://127.0.0.1/test'));
 		$this->assertNull($client->get('http://10.0.0.1/test'));
 		$this->assertNull($client->get('http://169.254.169.254/test'));
+		$this->assertNull($client->get('http://[::1]/test'));
+		$this->assertNull($client->get('http://[fd00::1]/test'));
+		$this->assertNull($client->get('http://2130706433/test'));
+		$this->assertNull($client->get('http://0177.0.0.1/test'));
+		$this->assertNull($client->get('http://0x7f000001/test'));
 	}
 
 	public function testGetReturnsNullForInvalidUrl(): void {

--- a/tests/OEmbed/OEmbedTest.php
+++ b/tests/OEmbed/OEmbedTest.php
@@ -209,6 +209,8 @@ class OEmbedTest extends TestCase {
 		$this->assertNull($discovery->fetch('file:///tmp/oembed.json'));
 		$this->assertNull($discovery->fetch('http://127.0.0.1/oembed'));
 		$this->assertNull($discovery->fetch('http://10.0.0.1/oembed'));
+		$this->assertNull($discovery->fetch('http://[::1]/oembed'));
+		$this->assertNull($discovery->fetch('http://2130706433/oembed'));
 	}
 
 	public function testOEmbedDiscoveryFetchWithDimensions(): void {
@@ -223,6 +225,27 @@ class OEmbedTest extends TestCase {
 
 		$discovery = new OEmbedDiscovery($mockClient);
 		$discovery->fetch('https://example.com/oembed?url=test', 640, 480);
+	}
+
+	public function testOEmbedDiscoveryFetchUsesRawQuerySeparator(): void {
+		$separator = ini_get('arg_separator.output');
+		ini_set('arg_separator.output', '&amp;');
+
+		try {
+			$mockClient = $this->createMock(HttpClientInterface::class);
+			$mockClient->expects($this->once())
+				->method('get')
+				->with($this->stringContains('maxwidth=640&maxheight=480'))
+				->willReturn(json_encode([
+					'type' => 'video',
+					'version' => '1.0',
+				]));
+
+			$discovery = new OEmbedDiscovery($mockClient);
+			$discovery->fetch('https://example.com/oembed?url=test', 640, 480);
+		} finally {
+			ini_set('arg_separator.output', $separator);
+		}
 	}
 
 }

--- a/tests/Provider/ProviderLoaderTest.php
+++ b/tests/Provider/ProviderLoaderTest.php
@@ -2,6 +2,8 @@
 
 namespace MediaEmbed\Test\Provider;
 
+use MediaEmbed\Exception\ProviderConfigException;
+use MediaEmbed\MediaEmbed;
 use MediaEmbed\Provider\ArrayLoader;
 use MediaEmbed\Provider\JsonFileLoader;
 use MediaEmbed\Provider\PhpFileLoader;
@@ -18,14 +20,66 @@ class ProviderLoaderTest extends TestCase {
 
 	public function testArrayLoaderLoad(): void {
 		$providers = [
-			['name' => 'Test1', 'website' => 'https://test1.com', 'url-match' => 'test1', 'embed-width' => '100', 'embed-height' => '100'],
-			['name' => 'Test2', 'website' => 'https://test2.com', 'url-match' => 'test2', 'embed-width' => '200', 'embed-height' => '200'],
+			['name' => 'Test1', 'website' => 'https://test1.com', 'url-match' => 'test1', 'embed-width' => '100', 'embed-height' => '100', 'iframe-player' => '//test1.com/embed/$2'],
+			['name' => 'Test2', 'website' => 'https://test2.com', 'url-match' => 'test2', 'embed-width' => '200', 'embed-height' => '200', 'iframe-player' => '//test2.com/embed/$2'],
 		];
 
 		$loader = new ArrayLoader($providers);
 
 		$this->assertTrue($loader->canLoad());
 		$this->assertSame($providers, $loader->load());
+	}
+
+	public function testMediaEmbedValidatesConstructorProviderLoader(): void {
+		$loader = new ArrayLoader([
+			[
+				'name' => 'Broken',
+				'website' => 'https://broken.example.com',
+				'url-match' => 'broken\\.example\\.com/([0-9]+)',
+				'embed-width' => 640,
+				'embed-height' => 360,
+			],
+		]);
+
+		$this->expectException(ProviderConfigException::class);
+		$this->expectExceptionMessage('Provider configuration is missing required field: iframe-player');
+
+		new MediaEmbed(providerLoader: $loader);
+	}
+
+	public function testMediaEmbedValidatesProviderLoaderMissingName(): void {
+		$loader = new ArrayLoader([
+			[
+				'website' => 'https://broken.example.com',
+				'url-match' => 'broken\\.example\\.com/([0-9]+)',
+				'embed-width' => 640,
+				'embed-height' => 360,
+				'iframe-player' => '//broken.example.com/embed/$2',
+			],
+		]);
+
+		$this->expectException(ProviderConfigException::class);
+		$this->expectExceptionMessage('Provider configuration is missing required field: name');
+
+		new MediaEmbed(providerLoader: $loader);
+	}
+
+	public function testMediaEmbedValidatesLoadedProviderLoader(): void {
+		$mediaEmbed = new MediaEmbed();
+		$loader = new ArrayLoader([
+			[
+				'name' => 'Broken',
+				'website' => 'https://broken.example.com',
+				'url-match' => 'broken\\.example\\.com/([0-9]+)',
+				'embed-width' => 640,
+				'embed-height' => 360,
+			],
+		]);
+
+		$this->expectException(ProviderConfigException::class);
+		$this->expectExceptionMessage('Provider configuration is missing required field: iframe-player');
+
+		$mediaEmbed->loadProvidersFromLoader($loader);
 	}
 
 	public function testPhpFileLoaderImplementsInterface(): void {

--- a/tests/link-check-config.json
+++ b/tests/link-check-config.json
@@ -48,6 +48,9 @@
 		},
 		{
 			"pattern": "^https://rumble.com"
+		},
+		{
+			"pattern": "^https://www.rutube.ru"
 		}
 	],
 	"aliveStatusCodes": [200, 202, 206, 429]


### PR DESCRIPTION
## Summary
- share public HTTP URL safety checks across stream and oEmbed fetching, including IPv6 and numeric loopback forms
- validate provider-loader entries through ProviderConfig before registration
- make ArrayCache distinguish cached null values from misses and honor TTL expiry
- use deterministic raw query separators for oEmbed fetch dimensions
- expand docs link checks and modernize examples for current iframe-only providers

## Validation
- composer cs-fix
- composer cs-check
- composer test
- composer stan
- composer validate-providers
- bin/generate-docs -d
- npx -y markdown-link-check README.md -p -c tests/link-check-config.json
- npx -y markdown-link-check docs/README.md -p -c tests/link-check-config.json
- npx -y markdown-link-check docs/supported.md -p -c tests/link-check-config.json
- npx -y markdown-link-check UPGRADE.md -p -c tests/link-check-config.json
- example URL parse/render smoke checks