### PR TITLE
Add safer default iframe attributes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -104,10 +104,12 @@ if ($MediaObject) {
 ```
 This should return an embed code like:
 ```html
-<iframe src="//www.youtube.com/embed/111111?wmode=transparent&amp;autoplay=1&amp;loop=1" width="480" height="295" frameborder="0" allowfullscreen class="iframe-class" data-html5-parameter></iframe>
+<iframe src="//www.youtube.com/embed/111111?wmode=transparent&amp;autoplay=1&amp;loop=1" title="YouTube embed" width="480" height="295" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" allow="fullscreen; picture-in-picture" frameborder="0" allowfullscreen class="iframe-class" data-html5-parameter></iframe>
 ```
 
 Attribute names must be valid iframe attribute names. Whitespace/control characters, HTML syntax characters, and `on*` event-handler attributes are rejected.
+Default iframe attributes include `title`, `loading="lazy"`, `referrerpolicy="strict-origin-when-cross-origin"`, `allow="fullscreen; picture-in-picture"`, `frameborder="0"`, and `allowfullscreen`. Override any default with `setAttribute()`, or remove it by setting the attribute value to `null` or `false`.
+`sandbox` is not enabled by default because most third-party embeds need provider-specific permissions. Add it explicitly when your target provider supports the restrictions you choose.
 
 Provider-specific iframe params can also be configured once when constructing `MediaEmbed`. This is useful for providers such as Twitch that require a domain-specific `parent` query parameter:
 

--- a/src/Object/MediaObject.php
+++ b/src/Object/MediaObject.php
@@ -485,11 +485,27 @@ class MediaObject implements ObjectInterface {
 		}
 		$this->iframeAttributes = [
 			'type' => 'text/html',
+			'title' => $this->titleAttribute(),
 			'width' => $stub['embed-width'],
 			'height' => $stub['embed-height'],
+			'loading' => 'lazy',
+			'referrerpolicy' => 'strict-origin-when-cross-origin',
+			'allow' => 'fullscreen; picture-in-picture',
 			'frameborder' => '0',
 			'allowfullscreen' => true,
 		];
+	}
+
+	/**
+	 * @return string
+	 */
+	protected function titleAttribute(): string {
+		$name = $this->name();
+		if (!$name) {
+			return 'Embedded media';
+		}
+
+		return $name . ' embed';
 	}
 
 	/**

--- a/tests/MediaEmbedTest.php
+++ b/tests/MediaEmbedTest.php
@@ -324,6 +324,41 @@ class MediaEmbedTest extends TestCase {
 		$this->assertStringNotContainsString(' hidden', $code);
 	}
 
+	public function testEmbedCodeIncludesDefaultIframeAttributes(): void {
+		$MediaEmbed = new MediaEmbed();
+		$Object = $MediaEmbed->parseUrl('https://www.youtube.com/watch?v=11111111111');
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		$code = $Object->getEmbedCode();
+
+		$this->assertStringContainsString(' title="YouTube embed"', $code);
+		$this->assertStringContainsString(' loading="lazy"', $code);
+		$this->assertStringContainsString(' referrerpolicy="strict-origin-when-cross-origin"', $code);
+		$this->assertStringContainsString(' allow="fullscreen; picture-in-picture"', $code);
+		$this->assertStringContainsString(' allowfullscreen', $code);
+	}
+
+	public function testEmbedCodeDefaultIframeAttributesCanBeOverridden(): void {
+		$MediaEmbed = new MediaEmbed();
+		$Object = $MediaEmbed->parseUrl('https://www.youtube.com/watch?v=11111111111');
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		$Object->setAttribute([
+			'title' => 'Custom video title',
+			'loading' => 'eager',
+			'referrerpolicy' => null,
+			'allow' => false,
+			'sandbox' => 'allow-scripts allow-same-origin',
+		]);
+		$code = $Object->getEmbedCode();
+
+		$this->assertStringContainsString(' title="Custom video title"', $code);
+		$this->assertStringContainsString(' loading="eager"', $code);
+		$this->assertStringNotContainsString(' referrerpolicy=', $code);
+		$this->assertStringNotContainsString(' allow=', $code);
+		$this->assertStringContainsString(' sandbox="allow-scripts allow-same-origin"', $code);
+	}
+
 	public function testProviderDefaultIframeParams(): void {
 		$MediaEmbed = new MediaEmbed();
 		$MediaEmbed->addProviderConfig(new ProviderConfig(


### PR DESCRIPTION
## Summary
- add default iframe title, lazy loading, referrer policy, and allow permissions
- keep sandbox opt-in because provider-safe permissions vary
- document overriding/removing default iframe attributes through setAttribute()
- cover defaults and overrides in MediaEmbed tests

## Validation
- composer cs-fix
- composer cs-check
- composer test
- composer stan
- composer validate-providers
- bin/generate-docs -d
- npx -y markdown-link-check README.md -p -c tests/link-check-config.json
- npx -y markdown-link-check docs/README.md -p -c tests/link-check-config.json
- npx -y markdown-link-check docs/supported.md -p -c tests/link-check-config.json
- npx -y markdown-link-check UPGRADE.md -p -c tests/link-check-config.json