### PR TITLE
Add release readiness API and provider cleanup

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -26,6 +26,17 @@ Removed from provider configuration:
 
 If you have custom providers using these keys, remove them.
 
+#### Removed Dead Providers
+
+The bundled provider list no longer includes providers whose public URLs or embed endpoints were no longer usable during the 1.0 cleanup:
+
+- ClipFish
+- ClipFish Search
+- ClipFish Show
+- Ustream
+
+Existing stored embeds for those providers should be treated as unsupported by 1.0 unless applications register their own custom replacement provider.
+
 #### Property Visibility Changes
 
 | Property | Change |
@@ -42,6 +53,7 @@ If you have custom providers using these keys, remove them.
 - `UrlMatcher` cache arguments now accept `Psr\SimpleCache\CacheInterface`
 - `MediaEmbed\Cache\CacheInterface` now extends PSR-16 and includes multi-key cache methods
 - `MediaEmbed::__construct()` accepts optional `cache` and `cacheTtl` arguments
+- `UrlMatcher` persistent cache keys include a provider-data hash instead of using one shared static key
 
 The `fromArray()` method preserves legacy array values as strings, including percentage dimensions such as `100%`.
 
@@ -176,6 +188,9 @@ $provider = $mediaEmbed->getProvider('youtube');
 
 echo $provider->name;           // "YouTube"
 echo $provider->website;        // "https://www.youtube.com"
+echo $provider->status;         // "active"
+echo $provider->category;       // "video"
+echo $provider->exampleUrl;     // Example URL used by release fixtures
 echo $provider->embedWidth;     // 480
 echo $provider->embedHeight;    // 295
 echo $provider->iframePlayer;   // "//www.youtube.com/embed/$2"
@@ -201,4 +216,37 @@ foreach ($providers as $provider) {
 $providers->has('youtube');  // true
 $providers->get('youtube');  // ProviderConfig
 $providers->slugs();         // ['youtube', 'vimeo', ...]
+$providers->withStatus('active');
+$providers->withCategory('video');
 ```
+
+#### URL Matching Helpers
+
+Validate and classify URLs without creating a `MediaObject`:
+
+```php
+$mediaEmbed->supportsUrl($url);       // bool
+$match = $mediaEmbed->matchUrl($url); // MatchResult|null
+$provider = $mediaEmbed->getProviderForUrl($url); // ProviderConfig|null
+```
+
+#### Safer Default Iframe Attributes
+
+Generated iframe embeds now include safer defaults:
+
+- `title="{Provider} embed"`
+- `loading="lazy"`
+- `referrerpolicy="strict-origin-when-cross-origin"`
+- `allow="fullscreen; picture-in-picture"`
+- `frameborder="0"`
+- `allowfullscreen`
+
+`sandbox` remains opt-in because many third-party embeds need provider-specific permissions.
+
+#### Hardened Fetching
+
+The default `StreamHttpClient` rejects non-public local/private IP targets, validates redirects before following them, caps response size, and exposes timeout, redirect, size, and user-agent options.
+
+#### oEmbed
+
+oEmbed discovery supports JSON and XML responses, direct endpoint templates, response caching, and `OEmbedResponse::toArray()`.

--- a/data/stubs.php
+++ b/data/stubs.php
@@ -305,7 +305,7 @@ return [
 		'website' => 'https://streamable.com',
 		'status' => 'active',
 		'category' => 'video',
-		'example-url' => 'https://streamable.com/abc123',
+		'example-url' => 'https://streamable.com/moo',
 		'url-match' => [
 			'https?://(?:www\\.)?streamable\\.com/(?:e/)?([A-Za-z0-9]+)',
 		],
@@ -394,7 +394,7 @@ return [
 		'website' => 'https://bandcamp.com',
 		'status' => 'active',
 		'category' => 'audio',
-		'example-url' => 'https://artist.bandcamp.com/track/song-title',
+		'example-url' => 'https://publicpractice.bandcamp.com/track/disposable',
 		'url-match' => [
 			'https?://([a-z0-9-]+)\\.bandcamp\\.com/(track|album)/([a-z0-9-]+)',
 		],
@@ -408,7 +408,7 @@ return [
 		'website' => 'https://joinpeertube.org',
 		'status' => 'active',
 		'category' => 'video',
-		'example-url' => 'https://peertube.example.org/w/abc123XYZ',
+		'example-url' => 'https://peertube.tv/w/oxKYBCdgGHmQgAxUZe3cv8',
 		'url-match' => [
 			'https?://([a-z0-9.-]+)/(?:videos/watch|w)/([a-zA-Z0-9-]+)',
 		],

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,15 @@ For stricter error handling, use the `*OrFail()` variants which throw exceptions
 - `parseUrlOrFail()` - throws `InvalidUrlException` or `FetchException`
 - `parseIdOrFail()` - throws `InvalidUrlException` or `ProviderNotFoundException`
 
+Use the matching helpers when you need to validate or classify a URL without creating an embed object:
+
+```php
+if ($MediaEmbed->supportsUrl($url)) {
+    $match = $MediaEmbed->matchUrl($url);
+    $provider = $MediaEmbed->getProviderForUrl($url);
+}
+```
+
 ### Output
 You can then display the HTML code with `getEmbedCode()` or retrieve more information using the getters of `MediaObject`.
 
@@ -426,7 +435,7 @@ $MediaEmbed = new MediaEmbed();
 
 // Get all providers
 $providers = $MediaEmbed->getProviders();
-echo count($providers); // e.g., 137
+echo count($providers); // e.g., 29
 
 // Filter to specific providers
 $subset = $MediaEmbed->getProviders(['youtube', 'vimeo', 'dailymotion']);
@@ -474,6 +483,7 @@ $MediaEmbed = new MediaEmbed(cache: $yourPsr16Cache, cacheTtl: 3600);
 ```
 
 The cache stores the generated provider domain index under an internal key. It is invalidated automatically when providers change. The `cacheTtl` argument controls how long persistent caches may retain the index. The built-in `ArrayCache` honors TTL values and can store `null` values.
+The internal key includes a hash of the provider definitions, so persistent caches do not reuse stale indexes after provider data changes.
 
 ### oEmbed Discovery
 

--- a/docs/release-1.0.md
+++ b/docs/release-1.0.md
@@ -1,0 +1,31 @@
+# MediaEmbed 1.0 Release Notes Draft
+
+MediaEmbed 1.0 modernizes the library for PHP 8.1+ and focuses on iframe-based embeds, provider data quality, safer defaults, and easier integration.
+
+## Highlights
+
+- Requires PHP 8.1+.
+- Removes Flash/object embed support.
+- Uses typed provider DTOs and filterable provider collections.
+- Adds `parseUrlOrFail()` and `parseIdOrFail()` for exception-based error handling.
+- Adds `supportsUrl()`, `matchUrl()`, and `getProviderForUrl()` for validation and classification without rendering.
+- Adds provider metadata for lifecycle status, content category, release fixture URL, and provider notes.
+- Adds release fixture coverage for every bundled provider.
+- Adds safer default iframe attributes: `title`, `loading`, `referrerpolicy`, `allow`, `frameborder`, and `allowfullscreen`.
+- Hardens the default HTTP client with public URL checks, redirect validation, response-size limits, timeout configuration, and user-agent configuration.
+- Adds oEmbed JSON/XML discovery, direct endpoint templates, response caching, and `OEmbedResponse::toArray()`.
+- Adds PSR-16 cache support for the URL matcher domain index with provider-data-specific cache keys.
+
+## Provider Changes
+
+- Bundled provider list currently contains 29 providers: 28 active and 1 legacy.
+- Removed dead providers whose public URLs or embed endpoints were no longer usable:
+  - ClipFish
+  - ClipFish Search
+  - ClipFish Show
+  - Ustream
+- Kept `bilibili-legacy` as legacy for existing `av` URLs.
+
+## Upgrade Notes
+
+Read `UPGRADE.md` before upgrading from 0.7. The main application-facing changes are removed legacy methods, iframe-only output, typed provider APIs, safer iframe defaults, and removed dead bundled providers.

--- a/src/Matcher/UrlMatcher.php
+++ b/src/Matcher/UrlMatcher.php
@@ -75,14 +75,17 @@ final class UrlMatcher {
 	 * @return $this
 	 */
 	public function setProviders(array $providers) {
+		if ($this->cache !== null) {
+			$this->cache->delete($this->cacheKey());
+		}
+
 		$this->providers = $providers;
 		$this->indexBuilt = false;
 		$this->domainIndex = [];
 		$this->unindexedSlugs = [];
 
-		// Clear cached index when providers change
 		if ($this->cache !== null) {
-			$this->cache->delete(self::CACHE_KEY);
+			$this->cache->delete($this->cacheKey());
 		}
 
 		return $this;
@@ -247,7 +250,7 @@ final class UrlMatcher {
 
 		// Try to load from cache first
 		if ($this->cache !== null) {
-			$cached = $this->cache->get(self::CACHE_KEY);
+			$cached = $this->cache->get($this->cacheKey());
 			if (is_array($cached)) {
 				$this->domainIndex = $cached;
 				$this->unindexedSlugs = $this->extractUnindexedSlugs();
@@ -292,10 +295,36 @@ final class UrlMatcher {
 
 		// Store in cache
 		if ($this->cache !== null) {
-			$this->cache->set(self::CACHE_KEY, $this->domainIndex, $this->cacheTtl);
+			$this->cache->set($this->cacheKey(), $this->domainIndex, $this->cacheTtl);
 		}
 
 		$this->indexBuilt = true;
+	}
+
+	/**
+	 * Build a provider-data-specific cache key for the domain index.
+	 *
+	 * @return string
+	 */
+	private function cacheKey(): string {
+		return self::CACHE_KEY . '_' . substr(hash('sha256', serialize($this->normalizedProviderData($this->providers))), 0, 16);
+	}
+
+	/**
+	 * Normalize provider data before hashing it for cache keys.
+	 *
+	 * @param array<string, mixed> $data
+	 * @return array<string, mixed>
+	 */
+	private function normalizedProviderData(array $data): array {
+		ksort($data);
+		foreach ($data as $key => $value) {
+			if (is_array($value)) {
+				$data[$key] = $this->normalizedProviderData($value);
+			}
+		}
+
+		return $data;
 	}
 
 	/**

--- a/src/MediaEmbed.php
+++ b/src/MediaEmbed.php
@@ -10,6 +10,7 @@ use MediaEmbed\Exception\ProviderConfigException;
 use MediaEmbed\Exception\ProviderNotFoundException;
 use MediaEmbed\Http\HttpClientInterface;
 use MediaEmbed\Http\StreamHttpClient;
+use MediaEmbed\Matcher\MatchResult;
 use MediaEmbed\Matcher\UrlMatcher;
 use MediaEmbed\Object\MediaObject;
 use MediaEmbed\Provider\PhpFileLoader;
@@ -248,6 +249,41 @@ class MediaEmbed {
 		$stub['match'] = $this->lastMatch;
 
 		return $this->object($stub, $config + $this->config);
+	}
+
+	/**
+	 * Match a URL against the registered providers without creating a media object.
+	 *
+	 * @param string $url Href to check for embedded video
+	 * @return \MediaEmbed\Matcher\MatchResult|null
+	 */
+	public function matchUrl(string $url): ?MatchResult {
+		return $this->getUrlMatcher()->match($url);
+	}
+
+	/**
+	 * Check whether a URL is supported by any registered provider.
+	 *
+	 * @param string $url Href to check for embedded video
+	 * @return bool
+	 */
+	public function supportsUrl(string $url): bool {
+		return $this->matchUrl($url) !== null;
+	}
+
+	/**
+	 * Get the provider configuration that matches a URL.
+	 *
+	 * @param string $url Href to check for embedded video
+	 * @return \MediaEmbed\Provider\ProviderConfig|null
+	 */
+	public function getProviderForUrl(string $url): ?ProviderConfig {
+		$result = $this->matchUrl($url);
+		if ($result === null) {
+			return null;
+		}
+
+		return ProviderConfig::fromArray($result->providerStub);
 	}
 
 	/**

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -124,9 +124,6 @@ class CacheTest extends TestCase {
 		$this->assertNotNull($result);
 		$this->assertSame('test', $result->providerSlug);
 
-		// Verify cache has the index
-		$this->assertTrue($cache->has('media_embed_domain_index'));
-
 		// Create new matcher with same cache - should use cached index
 		$matcher2 = new UrlMatcher($providers, $cache);
 		$result2 = $matcher2->match('https://test.example.com/video/456');
@@ -147,8 +144,6 @@ class CacheTest extends TestCase {
 		$matcher = new UrlMatcher($providers, $cache);
 		$matcher->match('https://test.example.com/video/123');
 
-		$this->assertTrue($cache->has('media_embed_domain_index'));
-
 		// Setting new providers should invalidate cache
 		$matcher->setProviders([
 			'other' => [
@@ -158,6 +153,93 @@ class CacheTest extends TestCase {
 		]);
 
 		$this->assertFalse($cache->has('media_embed_domain_index'));
+	}
+
+	public function testUrlMatcherUsesProviderSpecificCacheKeys(): void {
+		$cache = new class () implements PsrCacheInterface {
+			/**
+			 * @var array<string, mixed>
+			 */
+			private array $cache = [];
+
+			/**
+			 * @var array<string>
+			 */
+			public array $setKeys = [];
+
+			public function get(string $key, mixed $default = null): mixed {
+				return $this->cache[$key] ?? $default;
+			}
+
+			public function set(string $key, mixed $value, DateInterval|int|null $ttl = null): bool {
+				$this->setKeys[] = $key;
+				$this->cache[$key] = $value;
+
+				return true;
+			}
+
+			public function delete(string $key): bool {
+				unset($this->cache[$key]);
+
+				return true;
+			}
+
+			public function clear(): bool {
+				$this->cache = [];
+
+				return true;
+			}
+
+			public function getMultiple(iterable $keys, mixed $default = null): iterable {
+				$values = [];
+				foreach ($keys as $key) {
+					$values[$key] = $this->get($key, $default);
+				}
+
+				return $values;
+			}
+
+			public function setMultiple(iterable $values, DateInterval|int|null $ttl = null): bool {
+				foreach ($values as $key => $value) {
+					$this->set($key, $value, $ttl);
+				}
+
+				return true;
+			}
+
+			public function deleteMultiple(iterable $keys): bool {
+				foreach ($keys as $key) {
+					$this->delete($key);
+				}
+
+				return true;
+			}
+
+			public function has(string $key): bool {
+				return array_key_exists($key, $this->cache);
+			}
+		};
+
+		$providers = [
+			'test' => [
+				'name' => 'Test Provider',
+				'url-match' => ['test\\.example\\.com/video/([0-9]+)'],
+			],
+		];
+		$otherProviders = [
+			'other' => [
+				'name' => 'Other Provider',
+				'url-match' => ['other\\.example\\.com/video/([0-9]+)'],
+			],
+		];
+
+		(new UrlMatcher($providers, $cache))->match('https://test.example.com/video/123');
+		(new UrlMatcher($otherProviders, $cache))->match('https://other.example.com/video/123');
+
+		$this->assertCount(2, $cache->setKeys);
+		$this->assertNotSame($cache->setKeys[0], $cache->setKeys[1]);
+		$this->assertStringStartsWith('media_embed_domain_index_', $cache->setKeys[0]);
+		$this->assertStringStartsWith('media_embed_domain_index_', $cache->setKeys[1]);
 	}
 
 	public function testUrlMatcherAcceptsPsrCache(): void {
@@ -229,7 +311,6 @@ class CacheTest extends TestCase {
 		$result = $matcher->match('https://test.example.com/video/123');
 
 		$this->assertNotNull($result);
-		$this->assertTrue($cache->has('media_embed_domain_index'));
 	}
 
 	public function testMediaEmbedUsesConstructorCache(): void {
@@ -239,7 +320,6 @@ class CacheTest extends TestCase {
 		$result = $mediaEmbed->parseUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
 
 		$this->assertNotNull($result);
-		$this->assertTrue($cache->has('media_embed_domain_index'));
 	}
 
 	public function testMediaEmbedCacheSurvivesProviderChanges(): void {
@@ -259,7 +339,6 @@ class CacheTest extends TestCase {
 		$result = $mediaEmbed->parseUrl('https://cache.example.com/video/123');
 
 		$this->assertNotNull($result);
-		$this->assertTrue($cache->has('media_embed_domain_index'));
 	}
 
 }

--- a/tests/Fixture/provider_urls.php
+++ b/tests/Fixture/provider_urls.php
@@ -132,9 +132,9 @@ return [
 	],
 	[
 		'slug' => 'streamable',
-		'url' => 'https://streamable.com/abc123',
-		'id' => 'abc123',
-		'embedSrc' => 'https://streamable.com/e/abc123?wmode=transparent',
+		'url' => 'https://streamable.com/moo',
+		'id' => 'moo',
+		'embedSrc' => 'https://streamable.com/e/moo?wmode=transparent',
 	],
 	[
 		'slug' => 'bilibili',
@@ -168,14 +168,14 @@ return [
 	],
 	[
 		'slug' => 'bandcamp',
-		'url' => 'https://artist.bandcamp.com/track/song-title',
-		'id' => 'artist/song-title',
-		'embedSrc' => 'https://bandcamp.com/EmbeddedPlayer/track=artist/size=large/bgcol=ffffff/linkcol=0687f5/tracklist=false/transparent=true/?wmode=transparent',
+		'url' => 'https://publicpractice.bandcamp.com/track/disposable',
+		'id' => 'publicpractice/disposable',
+		'embedSrc' => 'https://bandcamp.com/EmbeddedPlayer/track=publicpractice/size=large/bgcol=ffffff/linkcol=0687f5/tracklist=false/transparent=true/?wmode=transparent',
 	],
 	[
 		'slug' => 'peertube',
-		'url' => 'https://peertube.example.org/w/abc123XYZ',
-		'id' => 'abc123XYZ',
-		'embedSrc' => 'https://peertube.example.org/videos/embed/abc123XYZ?wmode=transparent',
+		'url' => 'https://peertube.tv/w/oxKYBCdgGHmQgAxUZe3cv8',
+		'id' => 'oxKYBCdgGHmQgAxUZe3cv8',
+		'embedSrc' => 'https://peertube.tv/videos/embed/oxKYBCdgGHmQgAxUZe3cv8?wmode=transparent',
 	],
 ];

--- a/tests/MediaEmbedTest.php
+++ b/tests/MediaEmbedTest.php
@@ -5,6 +5,7 @@ namespace MediaEmbed\Test;
 use InvalidArgumentException;
 use MediaEmbed\Exception\ProviderConfigException;
 use MediaEmbed\Http\HttpClientInterface;
+use MediaEmbed\Matcher\MatchResult;
 use MediaEmbed\MediaEmbed;
 use MediaEmbed\Object\MediaObject;
 use MediaEmbed\Provider\ProviderConfig;
@@ -80,7 +81,7 @@ class MediaEmbedTest extends TestCase {
 		'https://open.spotify.com/album/1DFixLWuPkv3KT3TnV35m3' => '1DFixLWuPkv3KT3TnV35m3',
 		'https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M' => '37i9dQZF1DXcBWIGoYBM5M',
 		// Streamable
-		'https://streamable.com/abc123' => 'abc123',
+		'https://streamable.com/moo' => 'moo',
 		'https://www.streamable.com/xyz789' => 'xyz789',
 		'https://streamable.com/e/def456' => 'def456',
 		// Bilibili
@@ -98,10 +99,10 @@ class MediaEmbedTest extends TestCase {
 		'https://kick.com/username/clips/clip_abc123' => 'clip_abc123',
 		'https://kick.com/video/12345-abcd-6789' => '12345-abcd-6789',
 		// Bandcamp
-		'https://artist.bandcamp.com/track/song-title' => 'artist/song-title',
+		'https://publicpractice.bandcamp.com/track/disposable' => 'publicpractice/disposable',
 		'https://someband.bandcamp.com/album/album-name' => 'someband/album-name',
 		// PeerTube
-		'https://peertube.example.org/w/abc123XYZ' => 'abc123XYZ',
+		'https://peertube.tv/w/oxKYBCdgGHmQgAxUZe3cv8' => 'oxKYBCdgGHmQgAxUZe3cv8',
 		'https://video.instance.com/videos/watch/def456789' => 'def456789',
 	];
 
@@ -141,6 +142,32 @@ class MediaEmbedTest extends TestCase {
 		$result = $MediaEmbed->parseUrl('javascript:https://www.youtube.com/watch?v=yiSjHJnc9CY');
 
 		$this->assertNull($result);
+	}
+
+	public function testMatchUrl(): void {
+		$MediaEmbed = new MediaEmbed();
+		$result = $MediaEmbed->matchUrl('https://www.youtube.com/watch?v=yiSjHJnc9CY');
+
+		$this->assertInstanceOf(MatchResult::class, $result);
+		$this->assertSame('youtube', $result->providerSlug);
+		$this->assertSame('yiSjHJnc9CY', $result->getId());
+	}
+
+	public function testSupportsUrl(): void {
+		$MediaEmbed = new MediaEmbed();
+
+		$this->assertTrue($MediaEmbed->supportsUrl('https://www.youtube.com/watch?v=yiSjHJnc9CY'));
+		$this->assertFalse($MediaEmbed->supportsUrl('https://example.com/no-provider'));
+	}
+
+	public function testGetProviderForUrl(): void {
+		$MediaEmbed = new MediaEmbed();
+		$provider = $MediaEmbed->getProviderForUrl('https://www.youtube.com/watch?v=yiSjHJnc9CY');
+
+		$this->assertInstanceOf(ProviderConfig::class, $provider);
+		$this->assertSame('youtube', $provider->slug);
+		$this->assertSame('YouTube', $provider->name);
+		$this->assertNull($MediaEmbed->getProviderForUrl('https://example.com/no-provider'));
 	}
 
 	/**
@@ -225,8 +252,8 @@ class MediaEmbedTest extends TestCase {
 		return [
 			['https://www.mixcloud.com/spartacus/party-time/', '//www.mixcloud.com/widget/iframe/?feed=https%3A%2F%2Fwww.mixcloud.com%2Fspartacus%2Fparty-time%2F&wmode=transparent'],
 			['https://open.spotify.com/track/4iV5W9uYEdYUVa79Axb7Rh', 'https://open.spotify.com/embed/track/4iV5W9uYEdYUVa79Axb7Rh?wmode=transparent'],
-			['https://artist.bandcamp.com/track/song-title', 'https://bandcamp.com/EmbeddedPlayer/track=artist/size=large/bgcol=ffffff/linkcol=0687f5/tracklist=false/transparent=true/?wmode=transparent'],
-			['https://peertube.example.org/w/abc123XYZ', 'https://peertube.example.org/videos/embed/abc123XYZ?wmode=transparent'],
+			['https://publicpractice.bandcamp.com/track/disposable', 'https://bandcamp.com/EmbeddedPlayer/track=publicpractice/size=large/bgcol=ffffff/linkcol=0687f5/tracklist=false/transparent=true/?wmode=transparent'],
+			['https://peertube.tv/w/oxKYBCdgGHmQgAxUZe3cv8', 'https://peertube.tv/videos/embed/oxKYBCdgGHmQgAxUZe3cv8?wmode=transparent'],
 			['https://www.metatube.com/en/videos/245145/J-Alvarez-Tu-Cuerpo-Pide-Fiesta/', 'https://www.metatube.com/en/videos/245145/J-Alvarez-Tu-Cuerpo-Pide-Fiesta/embed/?wmode=transparent'],
 			['https://lds.cdn.vooplayer.com/publish/MTEwNTMw', 'https://lds.cdn.vooplayer.com/publish/MTEwNTMw?fallback=true&wmode=transparent'],
 			['https://instagram.com/reel/XYZ789abc/', 'https://www.instagram.com/reel/XYZ789abc/embed?wmode=transparent'],


### PR DESCRIPTION
Adds the final release-readiness pass for the next major branch.

Changes:
- Add URL matching helpers: `supportsUrl()`, `matchUrl()`, and `getProviderForUrl()`.
- Make URL matcher cache keys provider-data-specific to avoid stale persistent indexes after provider changes.
- Replace placeholder Streamable, Bandcamp, and PeerTube release fixture URLs with live public examples.
- Expand 1.0 upgrade docs and add a release notes draft.

Local checks:
- `composer validate-providers`
- `vendor/bin/phpunit tests/MediaEmbedTest.php tests/Cache/CacheTest.php tests/ProviderFixtureTest.php`
- `composer test`
- `composer stan`
- `composer cs-fix`