### PR TITLE
Document embedLocal() removal in upgrade guide

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -15,6 +15,7 @@ Version 1.0 modernizes the codebase with PHP 8.1+ features, removes deprecated m
 | `getHostOrFail(string $slug)` | `getProviderOrFail(string $slug)` |
 | `setHosts(array $stubs)` | Use constructor with `ProviderLoaderInterface` or `addProviderConfig()` |
 | `object(string $slug)` | `parseId(string $id, string $host)` or `getProvider(string $slug)` |
+| `embedLocal(string $file)` | Removed (was a non-functional no-op returning `false`); no replacement |
 | `MediaObject::setParam()` | `MediaObject::withParam()` |
 | `MediaObject::setAttribute()` | `MediaObject::withAttribute()` |
 | `MediaObject::setWidth()` | `MediaObject::withWidth()` |


### PR DESCRIPTION
Adds the one BC-removal missing from `UPGRADE.md`: the public `embedLocal(string $file): bool` method (a no-op returning `false` in 0.7) was dropped in 1.0. Lists it in the Removed Methods table so the upgrade guide covers the full public-API delta.

Found during a final 0.7.1 -> 1.0 public API diff; all other breaks were already documented.