### PR TITLE
Add GDPR click-to-load (two-click) consent placeholder

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -152,6 +152,45 @@ $MediaEmbed = new MediaEmbed(['privacy' => true]);
 
 Providers declare their privacy variant via the optional `privacy-player` (alternate URL template) and `privacy-params` (extra query params) stub keys, so custom providers can opt in too.
 
+### Click-to-load (GDPR two-click) placeholder
+
+For consent-driven (GDPR) pages, `getPlaceholderEmbedCode()` renders a lightweight placeholder instead of loading the third-party iframe immediately. No provider cookies or requests fire until the user clicks. The real iframe is held in a `<template>` and swapped in on click; a `<noscript>` fallback embeds it for users without JavaScript:
+
+```php
+$MediaObject = $this->MediaEmbed->parseUrl('https://www.youtube.com/watch?v=111111');
+echo $MediaObject->getPlaceholderEmbedCode();
+```
+
+Activation is handled by a small, CSP-friendly snippet you print **once per page** (it is idempotent and uses event delegation, so it covers any number of placeholders):
+
+```php
+echo '<script>' . \MediaEmbed\Object\MediaObject::placeholderScript() . '</script>';
+```
+
+The snippet contains no inline handlers or `eval`, so it works under a strict CSP - add a `nonce`/hash to the `<script>` tag as your policy requires.
+
+Options let you set the preview thumbnail, button label, extra CSS class, and aspect ratio:
+
+```php
+echo $MediaObject->getPlaceholderEmbedCode([
+    'thumbnail' => '/img/local-preview.jpg', // optional preview, see note below
+    'label' => 'Load video',
+    'class' => 'consent-box',
+    'ratio' => '4:3',
+]);
+```
+
+> [!IMPORTANT]
+> No thumbnail is loaded by default. A remote (provider-hosted) thumbnail would contact the third party before the user consents, which defeats the two-click purpose. Pass a local or proxied image URL, or `$this->MediaEmbed->thumbnail($MediaObject)` only if loading the provider thumbnail pre-consent is acceptable for your case. `MediaObject` itself never performs network requests.
+
+The `class` option is additive: the stable hook classes `media-embed-placeholder` / `media-embed-placeholder__button` are always present (so the activation script keeps working) and your class is appended to both.
+
+This pairs with privacy mode: create the object with `['privacy' => true]` and the templated iframe already uses the provider's privacy variant (e.g. `youtube-nocookie.com`).
+
+```html
+<div class="media-embed-placeholder" style="position:relative;width:100%;height:0;padding-bottom:56.25%;overflow:hidden;"><button type="button" class="media-embed-placeholder__button" style="..." aria-label="Load embedded content from YouTube">YouTube</button><template><iframe src="..." ...></iframe></template><noscript><iframe src="..." ...></iframe></noscript></div>
+```
+
 ### Responsive embeds
 
 `getResponsiveEmbedCode()` wraps the iframe in a fluid aspect-ratio container so it scales with its parent width. The default ratio is `16:9`; pass any `width:height` ratio:

--- a/src/Object/MediaObject.php
+++ b/src/Object/MediaObject.php
@@ -405,6 +405,129 @@ class MediaObject implements ObjectInterface {
 	}
 
 	/**
+	 * Convert the url to a GDPR-friendly "click-to-load" (two-click) consent placeholder.
+	 *
+	 * Instead of loading the third-party iframe immediately (which may set cookies or
+	 * contact the provider before consent), this renders a lightweight placeholder whose
+	 * real iframe lives inside a `<template>` and is only swapped in on user click. The
+	 * activation logic is provided by the shared, CSP-friendly snippet returned from
+	 * `placeholderScript()`, which you print once per page. A `<noscript>` fallback embeds
+	 * the real iframe for users without JavaScript.
+	 *
+	 * Pairs with privacy mode: when the object was created with `['privacy' => true]`, the
+	 * templated iframe already uses the provider's privacy variant (e.g. youtube-nocookie).
+	 *
+	 * @param array<string, mixed> $options Supported keys:
+	 *   - `thumbnail` (string|null): preview image URL. **No thumbnail is loaded by
+	 *     default** - a remote thumbnail would contact the third party before consent,
+	 *     defeating the purpose. Pass an explicit (ideally local/proxied) URL, or
+	 *     `MediaEmbed::thumbnail($object)` if loading the provider-hosted thumbnail
+	 *     pre-consent is acceptable for your use case.
+	 *   - `label` (string): button text. Defaults to the provider name.
+	 *   - `class` (string): extra CSS class(es) added to the wrapper (and `<class>` to the
+	 *     button). The stable hooks `media-embed-placeholder` / `media-embed-placeholder__button`
+	 *     are always present so `placeholderScript()` keeps working.
+	 *   - `ratio` (string): aspect ratio as "width:height". Defaults to `16:9`.
+	 * @throws \InvalidArgumentException When the ratio is malformed or has a zero component.
+	 * @return string The placeholder HTML
+	 */
+	public function getPlaceholderEmbedCode(array $options = []): string {
+		$extraClass = isset($options['class']) ? trim((string)$options['class']) : '';
+		$ratio = isset($options['ratio']) ? (string)$options['ratio'] : '16:9';
+		$label = isset($options['label']) ? (string)$options['label'] : ($this->name() ?: 'Embedded media');
+
+		// No thumbnail by default: a remote image would contact the third party before consent.
+		$thumbnail = isset($options['thumbnail']) ? (string)$options['thumbnail'] : '';
+
+		// Always keep the stable hook classes so the shared activation script matches,
+		// regardless of any extra class the caller adds.
+		$wrapperClass = 'media-embed-placeholder' . ($extraClass !== '' ? ' ' . $extraClass : '');
+		$buttonClass = 'media-embed-placeholder__button' . ($extraClass !== '' ? ' ' . $extraClass : '');
+
+		[$ratioWidth, $ratioHeight] = $this->parseRatio($ratio);
+		$paddingBottom = $ratioHeight / $ratioWidth * 100;
+
+		// Build the iframe with a fill style (matching getResponsiveEmbedCode()) so that,
+		// once swapped in, it fills the ratio box without a layout jump. Restore state after.
+		$originalAttributes = $this->iframeAttributes;
+		$existingStyle = isset($this->iframeAttributes['style']) ? rtrim((string)$this->iframeAttributes['style'], ';') . ';' : '';
+		$this->iframeAttributes['style'] = $existingStyle . 'position:absolute;top:0;left:0;width:100%;height:100%;border:0;';
+
+		try {
+			$iframe = $this->buildIframe();
+		} finally {
+			$this->iframeAttributes = $originalAttributes;
+		}
+
+		$buttonStyle = 'position:absolute;inset:0;width:100%;height:100%;border:0;cursor:pointer;'
+			. 'display:flex;align-items:center;justify-content:center;color:#fff;font:inherit;'
+			. 'background:#000 center/cover no-repeat;';
+		if ($thumbnail !== '') {
+			// Escape for the nested CSS url('...') context first, then esc() handles the
+			// surrounding HTML attribute. HTML escaping alone does not protect the CSS string.
+			$buttonStyle .= "background-image:url('" . $this->escCssString($thumbnail) . "');";
+		}
+
+		$ariaLabel = $this->name() !== '' ? sprintf('Load embedded content from %s', $this->name()) : 'Load embedded content';
+
+		return sprintf(
+			'<div class="%s" style="position:relative;width:100%%;height:0;padding-bottom:%s%%;overflow:hidden;">'
+				. '<button type="button" class="%s" style="%s" aria-label="%s">%s</button>'
+				. '<template>%s</template>'
+				. '<noscript>%s</noscript>'
+				. '</div>',
+			$this->esc($wrapperClass),
+			rtrim(rtrim(sprintf('%.4f', $paddingBottom), '0'), '.'),
+			$this->esc($buttonClass),
+			$this->esc($buttonStyle),
+			$this->esc($ariaLabel),
+			$this->esc($label),
+			$iframe,
+			$iframe,
+		);
+	}
+
+	/**
+	 * Escape a string for safe use inside a CSS single-quoted string (e.g. `url('...')`).
+	 *
+	 * Backslash-escapes the closing quote, double quote and backslash, and strips line
+	 * breaks. The result is still HTML-escaped by `esc()` for the surrounding `style`
+	 * attribute; this guards the nested CSS context that HTML escaping does not cover.
+	 *
+	 * @param string $value
+	 * @return string
+	 */
+	protected function escCssString(string $value): string {
+		$value = str_replace('\\', '\\\\', $value);
+		$value = str_replace(["'", '"'], ["\\'", '\\"'], $value);
+
+		return str_replace(["\r", "\n"], '', $value);
+	}
+
+	/**
+	 * Return the shared, CSP-friendly activation snippet for click-to-load placeholders.
+	 *
+	 * Print this once per page (e.g. before `</body>`), independent of how many
+	 * placeholders are rendered. It is idempotent (guarded against double execution) and
+	 * uses event delegation, so it also handles placeholders inserted after page load.
+	 * It contains no inline event handlers or `eval`, so it works under a strict CSP
+	 * (add a `nonce`/`sha` to the surrounding `<script>` tag as your policy requires).
+	 *
+	 * @return string The JavaScript snippet (without surrounding `<script>` tags).
+	 */
+	public static function placeholderScript(): string {
+		return '(function(){'
+			. 'if(window.__mediaEmbedPlaceholder)return;'
+			. 'window.__mediaEmbedPlaceholder=true;'
+			. 'document.addEventListener("click",function(e){'
+			. 'var b=e.target.closest(".media-embed-placeholder__button");if(!b)return;'
+			. 'var w=b.closest(".media-embed-placeholder");var t=w&&w.querySelector("template");if(!t)return;'
+			. 'w.replaceChildren(t.content.cloneNode(true));'
+			. '});'
+			. '})();';
+	}
+
+	/**
 	 * Whether the iframe source template is fully resolved (no leftover placeholders).
 	 *
 	 * Used by reverse lookups (`parseId()`) to detect IDs that cannot reconstruct a valid

--- a/src/Object/ObjectInterface.php
+++ b/src/Object/ObjectInterface.php
@@ -65,6 +65,20 @@ interface ObjectInterface {
 	public function getResponsiveEmbedCode(string $ratio = '16:9'): string;
 
 	/**
+	 * Returns a GDPR-friendly "click-to-load" consent placeholder.
+	 *
+	 * The real iframe is held in a `<template>` and only loaded on user click via the
+	 * shared snippet from `MediaObject::placeholderScript()`. A `<noscript>` fallback
+	 * embeds the real iframe for users without JavaScript.
+	 *
+	 * @api
+	 *
+	 * @param array<string, mixed> $options Supported: `thumbnail`, `label`, `class`, `ratio`.
+	 * @return string
+	 */
+	public function getPlaceholderEmbedCode(array $options = []): string;
+
+	/**
 	 * Returns the raw embed src URL. Useful when the caller controls escaping.
 	 *
 	 * @api

--- a/src/Object/ObjectInterface.php
+++ b/src/Object/ObjectInterface.php
@@ -6,6 +6,13 @@ namespace MediaEmbed\Object;
 
 /**
  * ObjectInterface must be implemented by classes that are a specific type of media.
+ *
+ * @method string getPlaceholderEmbedCode(array<string, mixed> $options = []) Returns a GDPR-friendly
+ *   "click-to-load" consent placeholder. The real iframe is held in a `<template>` and only loaded on
+ *   user click via the shared snippet from `MediaObject::placeholderScript()`. Implemented on
+ *   {@see \MediaEmbed\Object\MediaObject}; declared here as `@method` (not abstract) to avoid a BC
+ *   break for external implementers on the current minor line. Promote to an abstract method in the
+ *   next major. All `MediaEmbed::parse*()` calls return `MediaObject`, so callers can use it directly.
  */
 interface ObjectInterface {
 
@@ -63,20 +70,6 @@ interface ObjectInterface {
 	 * @return string
 	 */
 	public function getResponsiveEmbedCode(string $ratio = '16:9'): string;
-
-	/**
-	 * Returns a GDPR-friendly "click-to-load" consent placeholder.
-	 *
-	 * The real iframe is held in a `<template>` and only loaded on user click via the
-	 * shared snippet from `MediaObject::placeholderScript()`. A `<noscript>` fallback
-	 * embeds the real iframe for users without JavaScript.
-	 *
-	 * @api
-	 *
-	 * @param array<string, mixed> $options Supported: `thumbnail`, `label`, `class`, `ratio`.
-	 * @return string
-	 */
-	public function getPlaceholderEmbedCode(array $options = []): string;
 
 	/**
 	 * Returns the raw embed src URL. Useful when the caller controls escaping.

--- a/tests/MediaEmbedTest.php
+++ b/tests/MediaEmbedTest.php
@@ -671,6 +671,131 @@ class MediaEmbedTest extends TestCase {
 		$Object->getResponsiveEmbedCode('16:0');
 	}
 
+	public function testPlaceholderEmbedCodeWrapsIframeInTemplate(): void {
+		$MediaEmbed = new MediaEmbed();
+		$Object = $MediaEmbed->parseUrl('https://www.youtube.com/watch?v=11111111111');
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		$code = $Object->getPlaceholderEmbedCode();
+
+		$this->assertStringStartsWith('<div class="media-embed-placeholder" style="position:relative;width:100%;height:0;padding-bottom:56.25%;overflow:hidden;">', $code);
+		$this->assertStringContainsString('<button type="button" class="media-embed-placeholder__button"', $code);
+		$this->assertStringContainsString('<template><iframe', $code);
+		$this->assertStringContainsString('<noscript><iframe', $code);
+		$this->assertStringEndsWith('</div>', $code);
+	}
+
+	public function testPlaceholderEmbedCodeUsesProviderNameByDefault(): void {
+		$MediaEmbed = new MediaEmbed();
+		$Object = $MediaEmbed->parseUrl('https://www.youtube.com/watch?v=11111111111');
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		$code = $Object->getPlaceholderEmbedCode();
+
+		$this->assertStringContainsString('aria-label="Load embedded content from YouTube"', $code);
+		$this->assertStringContainsString('>YouTube</button>', $code);
+	}
+
+	public function testPlaceholderEmbedCodeKeepsStableHookClassesWhenCustomClassGiven(): void {
+		$MediaEmbed = new MediaEmbed();
+		$Object = $MediaEmbed->parseUrl('https://www.youtube.com/watch?v=11111111111');
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		$code = $Object->getPlaceholderEmbedCode(['label' => 'Play video', 'class' => 'consent-box']);
+
+		// Stable hooks must remain so placeholderScript() keeps matching; custom class is additive.
+		$this->assertStringContainsString('<div class="media-embed-placeholder consent-box"', $code);
+		$this->assertStringContainsString('class="media-embed-placeholder__button consent-box"', $code);
+		$this->assertStringContainsString('>Play video</button>', $code);
+	}
+
+	public function testPlaceholderEmbedCodeUsesExplicitThumbnailAsBackground(): void {
+		$MediaEmbed = new MediaEmbed();
+		$Object = $MediaEmbed->parseUrl('https://www.youtube.com/watch?v=11111111111');
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		$code = $Object->getPlaceholderEmbedCode(['thumbnail' => 'https://example.com/thumb.jpg']);
+
+		$this->assertStringContainsString('background-image:url(', $code);
+		$this->assertStringContainsString('https://example.com/thumb.jpg', $code);
+	}
+
+	public function testPlaceholderEmbedCodeOmitsThumbnailByDefault(): void {
+		$MediaEmbed = new MediaEmbed();
+		// Even though YouTube declares a static image-src, no remote thumbnail is loaded
+		// before consent by default - that would contact the third party prematurely.
+		$Object = $MediaEmbed->parseUrl('https://www.youtube.com/watch?v=11111111111');
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		$code = $Object->getPlaceholderEmbedCode();
+
+		$this->assertStringNotContainsString('background-image:', $code);
+		$this->assertStringNotContainsString('img.youtube.com', $code);
+	}
+
+	public function testPlaceholderEmbedCodeEscapesThumbnailForCssContext(): void {
+		$MediaEmbed = new MediaEmbed();
+		$Object = $MediaEmbed->parseUrl('https://www.youtube.com/watch?v=11111111111');
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		// A quote in the URL must not break out of the CSS url('...') string. esc() renders
+		// the apostrophe as &#039; (which the browser decodes back to '); the CSS-context
+		// fix prepends a backslash so the decoded char is an escaped quote (\') = safe.
+		$code = $Object->getPlaceholderEmbedCode(['thumbnail' => "https://evil/x');background:red;//"]);
+
+		// The apostrophe is backslash-escaped (\&#039;), so once the browser decodes the
+		// attribute the CSS sees \' (a literal quote) instead of a string-terminating quote.
+		$this->assertStringContainsString('\\&#039;', $code);
+	}
+
+	public function testPlaceholderEmbedCodeSupportsCustomRatio(): void {
+		$MediaEmbed = new MediaEmbed();
+		$Object = $MediaEmbed->parseUrl('https://www.youtube.com/watch?v=11111111111');
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		$this->assertStringContainsString('padding-bottom:75%;', $Object->getPlaceholderEmbedCode(['ratio' => '4:3']));
+	}
+
+	public function testPlaceholderEmbedCodeRejectsInvalidRatio(): void {
+		$MediaEmbed = new MediaEmbed();
+		$Object = $MediaEmbed->parseUrl('https://www.youtube.com/watch?v=11111111111');
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		$this->expectException(InvalidArgumentException::class);
+		$Object->getPlaceholderEmbedCode(['ratio' => '16:0']);
+	}
+
+	public function testPlaceholderEmbedCodeUsesPrivacyVariantWhenEnabled(): void {
+		$MediaEmbed = new MediaEmbed();
+		$Object = $MediaEmbed->parseUrl('https://www.youtube.com/watch?v=11111111111', ['privacy' => true]);
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		$code = $Object->getPlaceholderEmbedCode();
+
+		$this->assertStringContainsString('youtube-nocookie.com', $code);
+	}
+
+	public function testPlaceholderEmbedCodeFillsRatioBoxWithoutMutatingState(): void {
+		$MediaEmbed = new MediaEmbed();
+		$Object = $MediaEmbed->parseUrl('https://www.youtube.com/watch?v=11111111111');
+		$this->assertInstanceOf(MediaObject::class, $Object);
+
+		$code = $Object->getPlaceholderEmbedCode();
+
+		$this->assertStringContainsString('style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;"', $code);
+		$this->assertNull($Object->getAttributes('style'));
+		$this->assertStringNotContainsString('position:absolute', $Object->getEmbedCode());
+	}
+
+	public function testPlaceholderScriptIsIdempotentAndDelegated(): void {
+		$script = MediaObject::placeholderScript();
+
+		$this->assertStringContainsString('window.__mediaEmbedPlaceholder', $script);
+		$this->assertStringContainsString('addEventListener("click"', $script);
+		$this->assertStringContainsString('.media-embed-placeholder__button', $script);
+		$this->assertStringNotContainsString('eval', $script);
+	}
+
 	public function testEmbedCodeDefaultIframeAttributesCanBeOverridden(): void {
 		$MediaEmbed = new MediaEmbed();
 		$Object = $MediaEmbed->parseUrl('https://www.youtube.com/watch?v=11111111111');


### PR DESCRIPTION
Implements the optional GDPR "click-to-load" (two-click) consent placeholder from #109.

Instead of immediately loading a third-party iframe (which may set cookies / contact the provider before consent), `getPlaceholderEmbedCode()` renders a lightweight placeholder. The real iframe lives in a `<template>` and is only swapped in on user click. A `<noscript>` fallback embeds the real iframe for users without JavaScript.

## API

```php
// once per page (idempotent, event-delegated, CSP-friendly: no inline handlers, no eval)
echo '<script>' . \MediaEmbed\Object\MediaObject::placeholderScript() . '</script>';

$object = $MediaEmbed->parseUrl('https://www.youtube.com/watch?v=...');
echo $object->getPlaceholderEmbedCode([
    'thumbnail' => '/img/local-preview.jpg', // optional, see note
    'label' => 'Load video',
    'class' => 'consent-box',                 // additive, hook classes stay
    'ratio' => '16:9',
]);
```

- **Method, not a config flag** - render-time choice, mirrors `getResponsiveEmbedCode()` and keeps `getEmbedCode()` pure.
- **No thumbnail by default** - a remote (provider-hosted) thumbnail would contact the third party before consent, defeating the purpose. Pass a local/proxied URL, or `$MediaEmbed->thumbnail($object)` if loading the provider thumbnail pre-consent is acceptable.
- **CSP-friendly activation** - `placeholderScript()` uses event delegation on `document`, an idempotency guard, no inline handlers and no `eval`; add a `nonce`/hash as your policy requires.
- **Additive `class`** - the stable hooks `media-embed-placeholder` / `media-embed-placeholder__button` are always present so the script keeps matching; your class is appended.
- **Pairs with privacy mode** - when created with `['privacy' => true]`, the templated iframe already uses the provider's privacy variant (e.g. `youtube-nocookie.com`).
- Thumbnail URLs are escaped for the CSS `url('...')` context in addition to HTML escaping.
- Swapped-in iframe gets the same fill style as `getResponsiveEmbedCode()`, so there is no size jump on click.

## Screenshots

Before click - placeholder only, no third-party request:

![before](https://raw.githubusercontent.com/dereuromark/media-embed/assets/issue-109/screenshots/109/placeholder-before-click.png)

After click - real iframe swapped in from the `<template>`:

![after](https://raw.githubusercontent.com/dereuromark/media-embed/assets/issue-109/screenshots/109/placeholder-after-click.png)

(Screenshots live on the throwaway `assets/issue-109` branch, referenced via raw URL, so the code diff stays clean. Delete that branch after review.)

## Interface / BC

`getPlaceholderEmbedCode()` lives on `MediaObject` (the concrete type every `MediaEmbed::parse*()` returns, so callers use it directly). It is **not** added as an abstract method to `ObjectInterface` - that would break external implementers on the current minor line. Instead it is declared on the interface as an `@method` annotation for discoverability / static analysis. Promote it to a real abstract method in the next major.

## Docs / tests

- `docs/README.md`: new "Click-to-load (GDPR two-click) placeholder" section after privacy mode.
- `tests/MediaEmbedTest.php`: structure, template + noscript, default-no-thumbnail, explicit thumbnail, CSS-context escaping, additive class, custom ratio, invalid ratio, privacy combo, fill-style/no-mutation, script idempotency.